### PR TITLE
fix: pin chalk to 5.6.0 to avoid vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "update-notifier": "^7.3.1",
     "zod": "^3.24.1"
   },
+  "overrides": {
+    "chalk": "5.6.0"
+  },
   "contributors": [
     {
       "name": "Joe Caulfield",


### PR DESCRIPTION
## Summary
- Pin chalk dependency to version 5.6.0 to avoid security vulnerability in 5.6.1
- Add package override to ensure all transitive dependencies use the safe version

## Context
Version 5.6.1 of the chalk package contains a vulnerability where compromised packages could expose sensitive environment data through the `process.env` object.

This vulnerability is documented here: https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

## Changes
- Added `overrides` section to package.json to pin chalk to 5.6.0
- This ensures update-notifier and any other dependencies use the safe version

## Test plan
- [ ] Run `pnpm install` to update lockfile
- [ ] Verify chalk is resolved to 5.6.0 in node_modules
- [ ] Run existing tests to ensure no regressions