### PR TITLE
fix(test): error handling in search-and-replace test

### DIFF
--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -98,7 +98,7 @@ describe('searchAndReplace', () => {
   })
 
   it('should handle errors gracefully', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error')
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     // Mock the file system and simulate an error for readFile
     mockFs({


### PR DESCRIPTION
So basically, the "should handle errors gracefully" test was intentionally triggering errors to verify error handling, but `console.error` was not mocked to suppress output, causing noisy `stderr` logs during test despite all tests passing.

## Testing the introduced fix
```bash
npm run test
```
All tests will now pass cleanly without `stderr` error output.