### PR TITLE
fix: avoid repeated template rename replacements

### DIFF
--- a/.changeset/fix-overlapping-template-renames.md
+++ b/.changeset/fix-overlapping-template-renames.md
@@ -1,0 +1,5 @@
+---
+"create-solana-dapp": patch
+---
+
+Fix template renaming when the project name contains the template placeholder name.

--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -7,6 +7,20 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 }
 
+function replaceAllLiterals(value: string, fromStrings: string[], toStrings: string[]): string {
+  if (fromStrings.length === 0) {
+    return value
+  }
+
+  const replacementMap = new Map(fromStrings.map((fromString, index) => [fromString, toStrings[index]]))
+  const pattern = [...replacementMap.keys()]
+    .sort((a, b) => b.length - a.length)
+    .map((fromString) => escapeRegExp(fromString))
+    .join('|')
+
+  return value.replace(new RegExp(pattern, 'g'), (match) => replacementMap.get(match) ?? match)
+}
+
 export async function searchAndReplace(
   rootFolder: string,
   fromStrings: string[],
@@ -23,13 +37,10 @@ export async function searchAndReplace(
       const content = await readFile(filePath, 'utf8')
       let newContent = content
 
-      for (const [i, fromString] of fromStrings.entries()) {
-        const regex = new RegExp(escapeRegExp(fromString), 'g')
-        newContent = newContent.replace(regex, () => toStrings[i])
-        // Make sure we maintain the possible newline at the end of the file
-        if (content.endsWith('\n') && !newContent.endsWith('\n')) {
-          newContent += '\n'
-        }
+      newContent = replaceAllLiterals(content, fromStrings, toStrings)
+      // Make sure we maintain the possible newline at the end of the file
+      if (content.endsWith('\n') && !newContent.endsWith('\n')) {
+        newContent += '\n'
       }
 
       if (content !== newContent) {
@@ -99,9 +110,7 @@ export async function searchAndReplace(
         const oldPath = join(directoryPath, entry.name)
         let newName = entry.name
 
-        for (const [i, fromString] of fromStrings.entries()) {
-          newName = newName.replace(new RegExp(escapeRegExp(fromString), 'g'), () => toStrings[i])
-        }
+        newName = replaceAllLiterals(entry.name, fromStrings, toStrings)
 
         const newPath = join(directoryPath, newName)
 

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -66,6 +66,15 @@ describe('searchAndReplace', () => {
     await expect(access(join(tempDir, 'foo.bar.txt'))).rejects.toThrow()
   })
 
+  it('should not reprocess replacement text when names overlap', async () => {
+    await writeFile(join(tempDir, 'counter.ts'), 'export const name = "counter"')
+
+    await searchAndReplace(tempDir, ['counter'], ['my-counter'], false, false)
+
+    expect(await readFile(join(tempDir, 'my-counter.ts'), 'utf8')).toBe('export const name = "my-counter"')
+    await expect(access(join(tempDir, 'counter.ts'))).rejects.toThrow()
+  })
+
   it('should exclude directories like node_modules and .git from processing', async () => {
     const consoleLogSpy = vi.spyOn(console, 'log')
 


### PR DESCRIPTION
## Summary
- Makes search-and-replace substitutions single-pass so replacement text is not processed again by later substitutions
- Adds coverage for overlapping template names such as `counter` -> `my-counter`
- Adds a patch changeset

## Validation
- `pnpm test -- --run search-and-replace`

Closes #192
