### PR TITLE
fix: recover from a corrupt cached template archive

### DIFF
--- a/.changeset/recover-corrupt-template-archive.md
+++ b/.changeset/recover-corrupt-template-archive.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Recover from a corrupt cached template archive: retry the download once and, if it is still corrupt, explain which cache directory to clear instead of failing with a bare `ZlibError`

--- a/src/utils/corrupt-archive-error.ts
+++ b/src/utils/corrupt-archive-error.ts
@@ -1,0 +1,46 @@
+import { homedir, tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+/**
+ * Detects the errors thrown when the template tarball giget hands to `tar` is
+ * truncated or otherwise not a valid gzip archive.
+ *
+ * giget caches every template tarball. When a download is interrupted it leaves
+ * a partial file behind, and on the next run its download error handler falls
+ * back to that cached file instead of failing, so the corrupt archive is
+ * extracted and `tar` reports a low-level zlib failure (see #256).
+ */
+export function isCorruptArchiveError(error: unknown): boolean {
+  const code = (error as { code?: unknown })?.code
+  if (code === 'TAR_BAD_ARCHIVE' || code === 'Z_BUF_ERROR' || code === 'Z_DATA_ERROR') {
+    return true
+  }
+  const name = (error as { name?: unknown })?.name
+  const message = `${(error as { message?: unknown })?.message ?? error}`
+  return name === 'ZlibError' || /zlib|unexpected end of file|not a gzip|invalid distance/i.test(message)
+}
+
+/**
+ * The directory giget caches template tarballs in.
+ *
+ * Mirrors giget's own resolution so the recovery hint we print points at the
+ * directory the user actually needs to clear.
+ */
+export function templateCacheDirectory(): string {
+  if (process.platform === 'win32') {
+    return resolve(tmpdir(), 'giget')
+  }
+  return process.env.XDG_CACHE_HOME ? resolve(process.env.XDG_CACHE_HOME, 'giget') : resolve(homedir(), '.cache/giget')
+}
+
+/**
+ * Actionable message for a corrupt cached template archive, replacing the bare
+ * `ZlibError: zlib: unexpected end of file` that leaves users guessing (the
+ * reporter in #256 tried installing zlib).
+ */
+export function corruptArchiveMessage(templateId: string): string {
+  return [
+    `The cached archive for template ${templateId} is corrupt, most likely from an interrupted download.`,
+    `Delete the template cache and try again: ${templateCacheDirectory()}`,
+  ].join(' ')
+}

--- a/src/utils/create-app-task-clone-template.ts
+++ b/src/utils/create-app-task-clone-template.ts
@@ -2,8 +2,43 @@ import { log } from '@clack/prompts'
 import { downloadTemplate } from 'giget'
 import { cpSync, existsSync, mkdirSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
+import { corruptArchiveMessage, isCorruptArchiveError } from './corrupt-archive-error'
 import { GetArgsResult } from './get-args-result'
 import { Task, taskFail } from './vendor/clack-tasks'
+
+/**
+ * Downloads the template, retrying once when the cached tarball turns out to be
+ * corrupt (#256).
+ *
+ * giget only re-downloads when the previous attempt is not reused: if a partial
+ * tarball is already cached and the download errors, giget silently extracts the
+ * partial file and `tar` fails with a zlib error. A second attempt re-runs the
+ * download, which overwrites the poisoned cache entry when the network
+ * cooperates; if it does not, the user gets an actionable message instead of a
+ * bare `ZlibError`.
+ */
+async function downloadTemplateWithRetry(args: GetArgsResult) {
+  try {
+    return await downloadTemplate(args.template.id, { dir: args.targetDirectory })
+  } catch (error) {
+    if (!isCorruptArchiveError(error)) {
+      throw error
+    }
+    if (args.verbose) {
+      log.warn(`Cached template archive was corrupt, retrying download: ${error}`)
+    }
+    try {
+      // `forceClean` clears the partially extracted target directory the failed
+      // attempt may have left behind.
+      return await downloadTemplate(args.template.id, { dir: args.targetDirectory, forceClean: true })
+    } catch (retryError) {
+      if (isCorruptArchiveError(retryError)) {
+        throw new Error(corruptArchiveMessage(args.template.id))
+      }
+      throw retryError
+    }
+  }
+}
 
 export function createAppTaskCloneTemplate(args: GetArgsResult): Task {
   return {
@@ -45,10 +80,7 @@ export function createAppTaskCloneTemplate(args: GetArgsResult): Task {
 
           dir = args.targetDirectory
         } else {
-          const downloadResult = await downloadTemplate(args.template.id, {
-            dir: args.targetDirectory,
-          })
-          dir = downloadResult.dir
+          dir = (await downloadTemplateWithRetry(args)).dir
         }
 
         // make sure the dir is not empty

--- a/test/corrupt-archive-error.test.ts
+++ b/test/corrupt-archive-error.test.ts
@@ -1,0 +1,72 @@
+import { homedir, tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  corruptArchiveMessage,
+  isCorruptArchiveError,
+  templateCacheDirectory,
+} from '../src/utils/corrupt-archive-error'
+
+describe('isCorruptArchiveError', () => {
+  it('detects the zlib error tar throws for a truncated tarball', () => {
+    // The exact shape reported in #256.
+    const error = Object.assign(new Error('zlib: unexpected end of file'), { name: 'ZlibError' })
+    expect(isCorruptArchiveError(error)).toBe(true)
+  })
+
+  it('detects tar and zlib error codes', () => {
+    expect(isCorruptArchiveError(Object.assign(new Error('bad archive'), { code: 'TAR_BAD_ARCHIVE' }))).toBe(true)
+    expect(isCorruptArchiveError(Object.assign(new Error('buffer error'), { code: 'Z_BUF_ERROR' }))).toBe(true)
+    expect(isCorruptArchiveError(Object.assign(new Error('data error'), { code: 'Z_DATA_ERROR' }))).toBe(true)
+  })
+
+  it('detects a non-gzip payload', () => {
+    expect(isCorruptArchiveError(new Error('not a gzip file'))).toBe(true)
+  })
+
+  it('ignores unrelated failures', () => {
+    expect(isCorruptArchiveError(new Error('Destination /tmp/app already exists.'))).toBe(false)
+    expect(isCorruptArchiveError(Object.assign(new Error('offline'), { code: 'ENOTFOUND' }))).toBe(false)
+    expect(isCorruptArchiveError(undefined)).toBe(false)
+  })
+})
+
+describe('templateCacheDirectory', () => {
+  const platform = process.platform
+  const xdgCacheHome = process.env.XDG_CACHE_HOME
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: platform })
+    if (xdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = xdgCacheHome
+    }
+    vi.unstubAllEnvs()
+  })
+
+  it('uses the temp directory on Windows, matching giget', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    expect(templateCacheDirectory()).toBe(resolve(tmpdir(), 'giget'))
+  })
+
+  it('honours XDG_CACHE_HOME elsewhere', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    process.env.XDG_CACHE_HOME = '/custom/cache'
+    expect(templateCacheDirectory()).toBe(resolve('/custom/cache', 'giget'))
+  })
+
+  it('falls back to the home cache directory', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    delete process.env.XDG_CACHE_HOME
+    expect(templateCacheDirectory()).toBe(resolve(homedir(), '.cache/giget'))
+  })
+})
+
+describe('corruptArchiveMessage', () => {
+  it('names the template and the directory to clear', () => {
+    const message = corruptArchiveMessage('gh:solana-foundation/templates/nextjs-anchor')
+    expect(message).toContain('gh:solana-foundation/templates/nextjs-anchor')
+    expect(message).toContain(templateCacheDirectory())
+  })
+})

--- a/test/create-app-task-clone-template.test.ts
+++ b/test/create-app-task-clone-template.test.ts
@@ -1,0 +1,63 @@
+import { downloadTemplate } from 'giget'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { templateCacheDirectory } from '../src/utils/corrupt-archive-error'
+import { createAppTaskCloneTemplate } from '../src/utils/create-app-task-clone-template'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { taskFail } from '../src/utils/vendor/clack-tasks'
+
+vi.mock('giget', () => ({ downloadTemplate: vi.fn() }))
+vi.mock('node:fs', () => ({ cpSync: vi.fn(), existsSync: vi.fn(() => false), mkdirSync: vi.fn() }))
+vi.mock('node:fs/promises', () => ({ readdir: vi.fn(async () => ['package.json']) }))
+vi.mock('../src/utils/vendor/clack-tasks', () => ({ taskFail: vi.fn() }))
+
+function zlibError() {
+  // The failure reported in #256: giget extracted a truncated cached tarball.
+  return Object.assign(new Error('zlib: unexpected end of file'), { name: 'ZlibError' })
+}
+
+const args = {
+  targetDirectory: '/tmp/app',
+  template: { id: 'gh:solana-foundation/templates/nextjs-anchor' },
+  verbose: false,
+} as GetArgsResult
+
+describe('createAppTaskCloneTemplate: corrupt cached archive (#256)', () => {
+  const result = vi.fn((value) => value)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retries the download once when the cached archive is corrupt', async () => {
+    vi.mocked(downloadTemplate)
+      .mockRejectedValueOnce(zlibError())
+      .mockResolvedValueOnce({ dir: '/tmp/app' } as Awaited<ReturnType<typeof downloadTemplate>>)
+
+    await createAppTaskCloneTemplate(args).task(result)
+
+    expect(vi.mocked(downloadTemplate)).toHaveBeenCalledTimes(2)
+    // The retry clears whatever the failed attempt left in the target directory.
+    expect(vi.mocked(downloadTemplate).mock.calls[1][1]).toMatchObject({ forceClean: true })
+    expect(vi.mocked(taskFail)).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an actionable message when the retry is also corrupt', async () => {
+    vi.mocked(downloadTemplate).mockRejectedValue(zlibError())
+
+    await createAppTaskCloneTemplate(args).task(result)
+
+    expect(vi.mocked(downloadTemplate)).toHaveBeenCalledTimes(2)
+    const message = vi.mocked(taskFail).mock.calls[0][0] as string
+    expect(message).toContain(templateCacheDirectory())
+    expect(message).toContain('corrupt')
+  })
+
+  it('does not retry unrelated download failures', async () => {
+    vi.mocked(downloadTemplate).mockRejectedValue(new Error('Destination /tmp/app already exists.'))
+
+    await createAppTaskCloneTemplate(args).task(result)
+
+    expect(vi.mocked(downloadTemplate)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(taskFail)).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Fixes #256

## Problem

giget caches every template tarball under its cache directory. When a download is interrupted it leaves a partial file behind, and giget's own download error handler falls back to that cached file instead of failing:

```js
.catch((error) => {
  if (!existsSync(tarPath)) throw error
  // otherwise: silently reuse whatever is at tarPath
})
```

So the truncated archive is handed to `tar`, and the run dies with `ZlibError: zlib: unexpected end of file`. Nothing in that message mentions a cache, and because the poisoned entry survives, it reproduces on every retry — the reporter in #256 assumed it was a missing system dependency and tried installing zlib.

## Fix

- Detect corrupt-archive failures (`ZlibError`, `TAR_BAD_ARCHIVE`, `Z_BUF_ERROR`/`Z_DATA_ERROR`, non-gzip payloads).
- Retry the download **once**. A successful download overwrites the poisoned cache entry, so the common transient-interruption case now self-heals. The retry passes `forceClean` to clear whatever the failed attempt left in the target directory.
- If the retry is still corrupt, fail with an actionable message naming the template and the exact cache directory to delete (resolved the same way giget resolves it, including the Windows temp-dir case).
- Unrelated download failures (e.g. `Destination ... already exists.`) keep their existing behaviour and are not retried.

## Testing

11 new tests across `corrupt-archive-error` (error classification, cache-directory resolution on win32 / `XDG_CACHE_HOME` / home fallback, message contents) and `create-app-task-clone-template` (retries once and self-heals, actionable message when the retry is also corrupt, no retry for unrelated errors).

Suite: passing tests go 111 → 122; the 13 failures in `create-app-task-install-skills`, `get-package-json`, `get-version-commands` and `main` are pre-existing on `main` and untouched by this change. `eslint src/ test/` is clean.
