### PR TITLE
feat: select the template before the project name

### DIFF
--- a/.changeset/template-first-prompt-order.md
+++ b/.changeset/template-first-prompt-order.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Select the template before entering the project name, and pre-fill the name with the template name.

--- a/src/utils/get-prompt-name.ts
+++ b/src/utils/get-prompt-name.ts
@@ -1,14 +1,28 @@
 import { log, text } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
-import { validateProjectName } from './validate-project-name'
+import { Template } from './template'
+import { isValidProjectNameFormat, validateProjectName } from './validate-project-name'
+
+// Templates from the registry are named with a plain slug, but external (`org/repo`) and local
+// (`./path`) templates keep their raw reference as the name, so take the last path segment. Anything
+// that still isn't a usable directory name is dropped rather than rewritten: an invalid pre-fill is
+// worse than none, because it has to be cleared before the prompt will accept anything.
+function getInitialValue(template?: Template): string | undefined {
+  const candidate = template?.name.replace(/\/+$/, '').split('/').pop()
+
+  return candidate && isValidProjectNameFormat(candidate) ? candidate : undefined
+}
 
 export function getPromptName({ options }: { options: GetArgsResult }) {
-  return () => {
+  return ({ results }: { results: { template?: Template } }) => {
     if (options.name) {
       log.success(`Project name: ${options.name}`)
       return Promise.resolve(options.name)
     }
     return text({
+      // Pre-fill from the template selected in the previous prompt, so accepting the defaults all
+      // the way through gets you a working app
+      initialValue: getInitialValue(results.template),
       message: 'Enter project name',
       validate: (name) => validateProjectName(name ?? ''),
     })

--- a/src/utils/get-prompts.ts
+++ b/src/utils/get-prompts.ts
@@ -7,9 +7,11 @@ import { MenuItem } from './template-schema'
 
 export function getPrompts({ items, options }: { items: MenuItem[]; options: GetArgsResult }) {
   return group(
+    // The key order determines the prompt order: the template is selected first so it can seed the project name
     {
-      name: getPromptName({ options }),
+      // eslint-disable-next-line sort/object-properties
       template: getPromptTemplate({ items, options }),
+      name: getPromptName({ options }),
     },
     {
       onCancel: () => {

--- a/src/utils/validate-project-name.ts
+++ b/src/utils/validate-project-name.ts
@@ -1,8 +1,14 @@
 import { existsSync } from 'node:fs'
 
+// Checks the shape of a name without touching the filesystem, for callers that want to propose a
+// name rather than accept one. Keep this in sync with the first check in `validateProjectName`.
+export function isValidProjectNameFormat(name: string): boolean {
+  return /^[\w-]+$/i.test(name)
+}
+
 export function validateProjectName(name: string): string | undefined {
   // Name must be a valid directory name
-  if (!/^[\w-]+$/i.test(name)) {
+  if (!isValidProjectNameFormat(name)) {
     return 'Please enter a valid directory name (alphanumeric characters and dashes only)'
   }
   // Name must be at least 1 character long

--- a/test/get-prompts.test.ts
+++ b/test/get-prompts.test.ts
@@ -1,0 +1,121 @@
+import { select, text } from '@clack/prompts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { getPrompts } from '../src/utils/get-prompts'
+import type { Template } from '../src/utils/template'
+import type { MenuItem, TemplateJsonTemplate } from '../src/utils/template-schema'
+
+// Keep the real `group` so the prompt order is actually exercised, and stub the individual prompts
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@clack/prompts')>()
+  return {
+    ...actual,
+    cancel: vi.fn(),
+    log: { success: vi.fn() },
+    select: vi.fn(),
+    text: vi.fn(),
+  }
+})
+
+const template: TemplateJsonTemplate = {
+  description: 'A minimal template for building a Solana mobile app',
+  id: 'gh:solana-mobile/templates/mobile/expo-kit-minimal',
+  keywords: [],
+  name: 'expo-kit-minimal',
+  path: 'mobile/expo-kit-minimal',
+}
+
+const items: MenuItem[] = [
+  {
+    description: 'Solana Mobile Templates',
+    id: 'solana-mobile',
+    name: 'Solana Mobile',
+    templates: [template],
+  },
+]
+
+function getOptions(overrides: Partial<GetArgsResult> = {}): GetArgsResult {
+  return {
+    app: { name: 'create-solana-dapp', version: '0.0.0' },
+    dryRun: false,
+    name: '',
+    packageManager: 'npm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory: '',
+    template: undefined as unknown as Template,
+    verbose: false,
+    ...overrides,
+  }
+}
+
+function getTextOptions(call = 0) {
+  return vi.mocked(text).mock.calls[call][0]
+}
+
+describe('getPrompts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('asks for the template before the name and pre-fills the name with the template name', async () => {
+    vi.mocked(select).mockResolvedValueOnce(items[0]).mockResolvedValueOnce(template)
+    vi.mocked(text).mockResolvedValueOnce(template.name)
+
+    const result = await getPrompts({ items, options: getOptions() })
+
+    expect(vi.mocked(select).mock.calls[0][0].message).toBe('Select a group')
+    expect(vi.mocked(select).mock.calls[1][0].message).toBe('Select a template')
+    expect(getTextOptions().message).toBe('Enter project name')
+    // Both selects resolve before the name prompt is ever rendered
+    expect(vi.mocked(text).mock.invocationCallOrder[0]).toBeGreaterThan(vi.mocked(select).mock.invocationCallOrder[1])
+    expect(getTextOptions().initialValue).toBe('expo-kit-minimal')
+    expect(result).toEqual({ name: 'expo-kit-minimal', template })
+  })
+
+  it('pre-fills the name with a template passed on the command line', async () => {
+    vi.mocked(text).mockResolvedValueOnce(template.name)
+
+    await getPrompts({ items, options: getOptions({ template }) })
+
+    expect(select).not.toHaveBeenCalled()
+    expect(getTextOptions().initialValue).toBe('expo-kit-minimal')
+  })
+
+  it('does not prompt for a name that was passed on the command line', async () => {
+    vi.mocked(select).mockResolvedValueOnce(items[0]).mockResolvedValueOnce(template)
+
+    const result = await getPrompts({ items, options: getOptions({ name: 'my-app' }) })
+
+    expect(text).not.toHaveBeenCalled()
+    expect(result).toEqual({ name: 'my-app', template })
+  })
+
+  // `findTemplate` keeps the raw reference as the name for external and local templates
+  it.each([
+    ['an external template', 'solana-labs/dapp-kit', 'dapp-kit'],
+    ['a qualified external template', 'gh:solana-labs/dapp-kit', 'dapp-kit'],
+    ['a relative local template', './my-template', 'my-template'],
+    ['a parent-relative local template', '../shared/my-template', 'my-template'],
+    ['an absolute local template', '/Users/bee/dev/my-template', 'my-template'],
+    ['a trailing slash', 'solana-labs/dapp-kit/', 'dapp-kit'],
+  ])('pre-fills the name with the last path segment of %s', async (_, name, expected) => {
+    vi.mocked(text).mockResolvedValueOnce(expected)
+
+    await getPrompts({ items, options: getOptions({ template: { ...template, name } }) })
+
+    expect(getTextOptions().initialValue).toBe(expected)
+  })
+
+  it.each([
+    ['a segment that is not a usable directory name', './my.template'],
+    ['a path with no usable segment', '../'],
+  ])('leaves the name empty rather than proposing %s', async (_, name) => {
+    vi.mocked(text).mockResolvedValueOnce('my-app')
+
+    await getPrompts({ items, options: getOptions({ template: { ...template, name } }) })
+
+    expect(getTextOptions().initialValue).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## TLDR

We used to first ask for the name (if it wasn't provided as argument), then select the group/template.

Reversing this makes it so that we can suggest a name based on the template name. 



## Before
<img width="475" height="201" alt="image" src="https://github.com/user-attachments/assets/925f4ede-ff44-4aa4-a21d-83e91543e3a6" />

## After
<img width="594" height="272" alt="image" src="https://github.com/user-attachments/assets/f53bebc5-0e5d-4ebf-888c-6ec95b46cc1e" />


## Claude's Essay
The name prompt ran first, so you had to invent a directory name before seeing what you were scaffolding. Swap the order of the keys in the clack prompt group, which is what determines the prompt sequence, and seed the name prompt with the selected template's name as an editable initialValue. Enter now carries you through the whole flow to a working app.

Registry templates are named with a plain slug, but findTemplate keeps the raw reference as the name for external (org/repo) and local (./path) templates, so the pre-fill takes the last path segment. A proposed name that still isn't a usable directory name is dropped rather than rewritten, leaving the field empty: an invalid pre-fill is worse than none, because it has to be cleared before the prompt will accept anything.

Extract the format check out of validateProjectName as isValidProjectNameFormat so the pre-fill can test the shape of a name without the filesystem check. Keeping the two separate means a proposed name whose directory already exists is still offered, with the existing validation error, instead of silently dropped. The helper stays internal and is not added to the package root exports.
