### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yml
+++ b/.github/workflows/actions/install-dependencies/action.yml
@@ -10,16 +10,14 @@ runs:
   using: composite
   steps:
     - name: Install package manager
-      uses: pnpm/action-setup@v3
-      with:
-        version: 10.15.1
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.version }}
         cache: 'pnpm'
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,7 +23,7 @@ jobs:
       has_changesets: ${{ steps.check.outputs.has_changesets }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check for changesets
         id: check
@@ -42,7 +42,7 @@ jobs:
       NPM_CONFIG_PROVENANCE: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -59,12 +59,12 @@ jobs:
         run: pnpm exec publint --pack pnpm
 
       - name: Setup npm registry auth
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Create Changesets Pull Request or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           commit: 'chore: version packages'
           publish: pnpm publish-packages
@@ -85,7 +85,7 @@ jobs:
       NPM_CONFIG_PROVENANCE: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Dependencies
         uses: ./.github/workflows/actions/install-dependencies
@@ -105,7 +105,7 @@ jobs:
         run: pnpm exec publint --pack pnpm
 
       - name: Setup npm registry auth
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/publish-pkg-pr-new.yml
+++ b/.github/workflows/publish-pkg-pr-new.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Dependencies
         uses: ./.github/workflows/actions/install-dependencies

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Dependencies
         uses: ./.github/workflows/actions/install-dependencies

--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test & Lint on Node ${{ matrix.node }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Dependencies
         uses: ./.github/workflows/actions/install-dependencies


### PR DESCRIPTION
Pin all external action `uses:` references to commit SHAs with version comments, bumping checkout v4 -> v7.0.1, setup-node v4 -> v7.0.0, changesets/action v1 -> v1.9.0, and pnpm/action-setup v3 -> v6.0.10.

Drop the hardcoded pnpm `version` input from the install-dependencies composite action: pnpm/action-setup v4+ errors when that input conflicts with the `packageManager` field, which it did (10.15.1 vs 10.34.5). pnpm now resolves from `packageManager` alone.

Also add `--frozen-lockfile` to `pnpm install` so lockfile drift fails CI instead of silently resolving.
