### PR TITLE
feat: tighten project name validation and export it as a reusable zod schema

### DIFF
--- a/.changeset/project-name-schema.md
+++ b/.changeset/project-name-schema.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Tighten project name validation to lowercase kebab-case npm package names and export the rule as a reusable `projectNameSchema` zod schema. Names with uppercase characters, underscores, dots, or leading/trailing/consecutive dashes are now rejected at the prompt, since the project name is written into the generated `package.json` and used as the search key when renaming the template.

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export type {
   TemplateJsonGroup,
   TemplateJsonTemplate,
 } from './utils/template-schema'
-export { validateProjectName } from './utils/validate-project-name'
+export { projectNameSchema, validateProjectName } from './utils/validate-project-name'
 export { detectInvokedPackageManager } from './utils/vendor/package-manager'
 export type { PackageManager } from './utils/vendor/package-manager'
 

--- a/src/utils/validate-project-name.ts
+++ b/src/utils/validate-project-name.ts
@@ -1,19 +1,28 @@
 import { existsSync } from 'node:fs'
+import { z } from 'zod'
+
+// The project name becomes the name of the generated package and the search key the init
+// script uses to rename the template, so it must be a valid npm package name: lowercase
+// letters, digits, and single dashes, starting with a letter. npm caps names at 214 characters.
+export const projectNameSchema = z
+  .string()
+  .min(1, 'Please enter at least 1 character')
+  .max(214, 'Please enter a name with at most 214 characters')
+  .regex(
+    /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/,
+    'Please enter a valid project name (lowercase letters, numbers, and single dashes, starting with a letter)',
+  )
 
 // Checks the shape of a name without touching the filesystem, for callers that want to propose a
-// name rather than accept one. Keep this in sync with the first check in `validateProjectName`.
+// name rather than accept one.
 export function isValidProjectNameFormat(name: string): boolean {
-  return /^[\w-]+$/i.test(name)
+  return projectNameSchema.safeParse(name).success
 }
 
 export function validateProjectName(name: string): string | undefined {
-  // Name must be a valid directory name
-  if (!isValidProjectNameFormat(name)) {
-    return 'Please enter a valid directory name (alphanumeric characters and dashes only)'
-  }
-  // Name must be at least 1 character long
-  if (name.length === 0) {
-    return 'Please enter at least 1 character'
+  const result = projectNameSchema.safeParse(name)
+  if (!result.success) {
+    return result.error.issues[0].message
   }
   // Check if the directory already exists
   if (existsSync(name)) {

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -10,6 +10,7 @@ import {
   InitScriptSchemaSkills,
   InitScriptSchemaVersions,
   parseTemplateJson,
+  projectNameSchema,
   templateJsonGroupSchema,
   templateJsonSchema,
   templateJsonTemplateSchema,
@@ -25,6 +26,7 @@ import type {
 } from '../src/index'
 import * as initScriptSchemaModule from '../src/utils/init-script-schema'
 import * as templateSchemaModule from '../src/utils/template-schema'
+import * as validateProjectNameModule from '../src/utils/validate-project-name'
 
 const templateGroup = {
   description: 'Templates for mobile apps',
@@ -98,6 +100,14 @@ describe('package root schema exports', () => {
     expect(InitScriptSchemaSkills).toBe(initScriptSchemaModule.InitScriptSchemaSkills)
     expect(InitScriptSchemaVersions).toBe(initScriptSchemaModule.InitScriptSchemaVersions)
     expect(initScriptKey).toBe(initScriptSchemaModule.initScriptKey)
+  })
+
+  it('exports the project name schema', () => {
+    // The root export must be the same instance the CLI uses, not a copy
+    expect(projectNameSchema).toBe(validateProjectNameModule.projectNameSchema)
+
+    expect(projectNameSchema.safeParse('my-app').success).toBe(true)
+    expect(projectNameSchema.safeParse('My_App').success).toBe(false)
   })
 
   it('validates a template catalog through the root exports', () => {

--- a/test/validate-project-name.test.ts
+++ b/test/validate-project-name.test.ts
@@ -1,0 +1,64 @@
+import { fs, vol } from 'memfs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { projectNameSchema, validateProjectName } from '../src/utils/validate-project-name'
+
+vi.mock('node:fs')
+
+const invalidNameMessage =
+  'Please enter a valid project name (lowercase letters, numbers, and single dashes, starting with a letter)'
+
+describe('validateProjectName', () => {
+  beforeEach(() => {
+    vol.reset()
+  })
+
+  it.each(['a', 'app', 'my-app', 'my-app-2', 'web3'])('should accept %j', (name) => {
+    expect(validateProjectName(name)).toBeUndefined()
+  })
+
+  it.each([
+    ['a leading dash', '-app'],
+    ['a leading digit', '9lives'],
+    ['a scoped package name', '@scope/app'],
+    ['a space', 'my app'],
+    ['a trailing dash', 'app-'],
+    ['a double dash', 'my--app'],
+    ['a dot', 'my.app'],
+    ['an underscore', 'my_app'],
+    ['uppercase characters', 'My-App'],
+  ])('should reject a name with %s (%j)', (_, name) => {
+    expect(validateProjectName(name)).toBe(invalidNameMessage)
+  })
+
+  it('should reject an empty name', () => {
+    expect(validateProjectName('')).toBe('Please enter at least 1 character')
+  })
+
+  it('should reject a name longer than 214 characters', () => {
+    expect(validateProjectName('a'.repeat(215))).toBe('Please enter a name with at most 214 characters')
+  })
+
+  it('should accept a name of exactly 214 characters', () => {
+    expect(validateProjectName('a'.repeat(214))).toBeUndefined()
+  })
+
+  it('should reject a valid name when the directory already exists', () => {
+    fs.mkdirSync(join(process.cwd(), 'my-app'), { recursive: true })
+
+    expect(validateProjectName('my-app')).toBe('Directory already exists')
+  })
+})
+
+describe('projectNameSchema', () => {
+  it('should be reusable as a plain zod schema', () => {
+    expect(projectNameSchema.safeParse('my-app').success).toBe(true)
+    expect(projectNameSchema.safeParse('My_App').success).toBe(false)
+  })
+
+  it('should not check the filesystem', () => {
+    fs.mkdirSync(join(process.cwd(), 'my-app'), { recursive: true })
+
+    expect(projectNameSchema.safeParse('my-app').success).toBe(true)
+  })
+})


### PR DESCRIPTION
## Why

The project name is written into the generated `package.json` and used as the search key for the init script rename, so it must be a valid npm package name. The old rule (`/^[\w-]+$/i`) accepted names like `My_App`, `_x`, and `9lives` that broke both.

## What

- **New `projectNameSchema` export** — the pure validation rule as a zod schema, so downstream consumers can reuse and compose it. Accepts lowercase kebab-case only: a lowercase letter followed by lowercase letters, digits, and single dashes, max 214 characters (the npm limit).
- **`validateProjectName` keeps its exact signature** (`(name: string) => string | undefined`) and behaviour contract: schema check first, then the `Directory already exists` check.
- **Fixes a dead branch** — the empty-name message was unreachable behind the old regex; it is now reachable via the schema's min-length check.

## Notes

- Names that previously passed the prompt (`My_App`, `my_app`) are now rejected — they always produced an invalid npm package name and a degenerate rename search key downstream, so this ships as a `minor`.
- The positional CLI `name` argument still bypasses validation entirely (only the prompt path validates); that's a pre-existing gap tracked for a separate change.
