### PR TITLE
fix: ship the CLI bin as ESM and raise the Node floor to 22.12

### DIFF
--- a/.changeset/esm-bin-node-22-floor.md
+++ b/.changeset/esm-bin-node-22-floor.md
@@ -1,0 +1,10 @@
+---
+'create-solana-dapp': minor
+---
+
+Ship the CLI entry point as ESM and raise the Node floor to `>=22.12.0`. The published `bin` previously pointed at a
+CommonJS bundle that called `require()` on four ESM-only dependencies (`@clack/prompts`, `giget`, `is-in-ci`,
+`update-notifier`), which only resolved through Node's `require(esm)` support and therefore crashed with
+`ERR_REQUIRE_ESM` on Node 20.12 through 20.18. The bin is now `dist/bin/index.mjs` and the new floor guarantees
+`require(esm)` for the CommonJS library entry that is still published for `require('create-solana-dapp')` consumers.
+Node 20 reached end of life on 2026-04-30.

--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         node:
+          - '22.12.0'
           - 'current'
           - 'lts/*'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ In another terminal, move to the directory where you want to test the `create-so
 
 ```shell
 cd /tmp
-node ~/path/to/create-solana-dapp/dist/bin/index.cjs --help
+node ~/path/to/create-solana-dapp/dist/bin/index.mjs --help
 ```
 
 ### Committing Your Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache bash git
 RUN echo "export PS1='\w # '" >> ~/.bashrc
 
 RUN corepack enable && corepack use pnpm@latest-10
-RUN echo "export CMD=\"node /workspace/dist/bin/index.cjs --pnpm --verbose\"" >> ~/.bashrc
+RUN echo "export CMD=\"node /workspace/dist/bin/index.mjs --pnpm --verbose\"" >> ~/.bashrc
 
 COPY csd.sh /usr/local/bin/csd
 

--- a/csd.sh
+++ b/csd.sh
@@ -23,7 +23,7 @@
 # $ TAG=next csd
 #
 # Create an app using a local create-solana-dapp command. Run `pnpm build:watch` in the create-solana-dapp directory to watch for changes.
-# $ CMD="node $HOME/path/to/create-solana-dapp/dist/bin/index.cjs --pnpm" csd
+# $ CMD="node $HOME/path/to/create-solana-dapp/dist/bin/index.mjs --pnpm" csd
 #
 # Create an app using npx
 # $ CMD="npx -y create-solana-dapp@latest" csd

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.5",
   "description": "The fastest way to create Solana apps",
   "engines": {
-    "node": ">=20.12.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "name": "solana-foundation/create-solana-dapp",
@@ -31,7 +31,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "bin": {
-    "create-solana-dapp": "./dist/bin/index.cjs"
+    "create-solana-dapp": "./dist/bin/index.mjs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Why

The published `bin` pointed at a CommonJS bundle that called `require()` on four ESM-only dependencies (`@clack/prompts`, `giget`, `is-in-ci`, `update-notifier`). Those calls only resolved through Node's `require(esm)` support, which is unflagged in 20.19.0 and 22.12.0, so the CLI failed with `ERR_REQUIRE_ESM` across the 20.12 through 20.18 range that `engines` still allowed. The source has been ESM (`"type": "module"`) all along, so only the published entry point needed to change.

## What

- Point `bin` at `dist/bin/index.mjs`. unbuild derives the entry format from `pkg.bin`, so no `build.config.ts` was needed; the emitted file keeps its shebang and `0755` bit and imports `../index.mjs`.
- Raise `engines.node` to `>=22.12.0`, which guarantees `require(esm)` for the CommonJS library entry that is still published for `require('create-solana-dapp')` consumers.
- Add `22.12.0` to the test matrix, which previously ran only `current` and `lts/*`, so the `engines` floor is exercised in CI rather than just asserted.
- Update the three development paths that referenced the old extension (the `Dockerfile`, the `csd.sh` usage comment, and the local CLI testing instructions in `CONTRIBUTING.md`), plus a `minor` changeset.

## Notes

Node 20 reached end of life on 2026-04-30, so raising the floor withdraws no active support and ships as a `minor`. `dist/bin/index.cjs` is still emitted but unreferenced, because unbuild derives formats globally from `pkg.main` and `exports.require`; it is a 521-byte wrapper around the `index.cjs` that is still published, and it goes away when the CommonJS library entry is dropped.
