### PR TITLE
feat: validate the positional name argument against the project name rules

### DIFF
--- a/.changeset/validate-positional-name.md
+++ b/.changeset/validate-positional-name.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Validate the positional `name` CLI argument with the same rules as the interactive prompt. Previously `npx create-solana-dapp My_App` bypassed validation entirely and produced an invalid npm package name and a degenerate rename search key; it now fails with the validation message.

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -14,6 +14,7 @@ import { listTemplates } from './list-templates'
 import { listVersions } from './list-versions'
 import { runVersionCheck } from './run-version-check'
 import { Template } from './template'
+import { validateProjectName } from './validate-project-name'
 import { PackageManager } from './vendor/package-manager'
 
 const minimalTemplateName = 'nextjs-anchor'
@@ -60,6 +61,19 @@ Examples:
   // Get the options from the command line
   const result = input.opts()
   const verbose = result.verbose ?? false
+
+  // The positional name flows into the generated package.json and the rename search key, so it
+  // must pass the same validation as the interactive prompt. Validate before fetching template
+  // data so a network failure can't mask the name error, but not for the informational list
+  // commands, which only use the name to build a hint.
+  const isListCommand = result.listTemplateIds || result.listTemplates || result.listVersions
+  if (name && !isListCommand) {
+    const nameError = validateProjectName(name)
+    if (nameError) {
+      log.error(nameError)
+      throw new Error(nameError)
+    }
+  }
 
   // Fetch the templates url, parse the template data and create menu items following our menu config
   const { items, templates } = await fetchTemplateData({ config: getMenuConfig(), url: result.templatesUrl, verbose })

--- a/test/get-args.test.ts
+++ b/test/get-args.test.ts
@@ -26,6 +26,16 @@ vi.mock('../src/utils/get-prompts', () => ({
   getPrompts: vi.fn(),
 }))
 
+vi.mock('node:process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:process')>()
+  return {
+    ...actual,
+    exit: vi.fn((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }),
+  }
+})
+
 vi.mock('../src/utils/run-version-check', () => ({
   runVersionCheck: vi.fn(),
 }))
@@ -128,6 +138,43 @@ describe('getArgs', () => {
     expect(args.name).toBe('my-app')
     expect(args.templateOptions).toEqual(['llamacpp'])
     expect(args.template).toBe(template)
+  })
+
+  it('rejects an invalid positional project name', async () => {
+    const message =
+      'Please enter a valid project name (lowercase letters, numbers, and single dashes, starting with a letter)'
+
+    await expect(
+      getArgs(['node', 'create-solana-dapp', 'My_App', '--template', 'basic', '--skip-version-check'], app),
+    ).rejects.toThrow(message)
+
+    expect(log.error).toHaveBeenCalledWith(message)
+    expect(fetchTemplateData).not.toHaveBeenCalled()
+    expect(getPrompts).not.toHaveBeenCalled()
+  })
+
+  it('rejects a positional project name whose directory already exists', async () => {
+    // The 'test' directory exists in the repo root, which is the cwd when running vitest
+    await expect(
+      getArgs(['node', 'create-solana-dapp', 'test', '--template', 'basic', '--skip-version-check'], app),
+    ).rejects.toThrow('Directory already exists')
+
+    expect(log.error).toHaveBeenCalledWith('Directory already exists')
+    expect(fetchTemplateData).not.toHaveBeenCalled()
+    expect(getPrompts).not.toHaveBeenCalled()
+  })
+
+  it('skips project name validation for informational list commands', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await expect(
+      getArgs(['node', 'create-solana-dapp', 'My_App', '--list-template-ids', '--skip-version-check'], app),
+    ).rejects.toThrow('process.exit(0)')
+
+    expect(log.error).not.toHaveBeenCalled()
+    expect(consoleLog).toHaveBeenCalledWith(JSON.stringify([template.id]))
+
+    consoleLog.mockRestore()
   })
 
   it('parses positional and registered arguments after a template-defined flag', async () => {


### PR DESCRIPTION
## Why

The positional CLI `name` argument flowed straight from `input.args[0]` into the generated `package.json` name and the init-script rename search key without ever passing through `validateProjectName` — only the interactive prompt path validated. So `npx create-solana-dapp My_App` bypassed validation entirely and produced an invalid npm package name and a degenerate rename search key.

## What

- Run `validateProjectName` on the positional argument in `getArgs` when it is provided (the same rule as the interactive prompt, including the `Directory already exists` check) and throw with the validation message on failure, matching the existing `log.error` + `throw` pattern.
- Validation runs immediately after argument parsing, before `fetchTemplateData`, so a network failure can't mask the name-validation error. The informational `--list-*` commands skip it, since they only use the name to build a hint.
- Test coverage for both rejection paths (including asserting the template fetch is never reached) and for the list-command exemption, plus a `minor` changeset.

## Notes

Stacked on #274 (targets `beeman/project-name-schema`); retarget to `main` or rebase once that merges.