### PR TITLE
fix: apply init-script renames in a single pass per file

### DIFF
--- a/.changeset/single-pass-init-rename.md
+++ b/.changeset/single-pass-init-rename.md
@@ -1,0 +1,6 @@
+---
+'create-solana-dapp': patch
+---
+
+Apply every init-script rename in a single pass per file, so a project name that contains a template
+term is no longer compounded (`mycountergill` no longer became `mymycountergillgill`).

--- a/src/utils/create-app-task-run-init-script.ts
+++ b/src/utils/create-app-task-run-init-script.ts
@@ -33,12 +33,12 @@ export function createAppTaskRunInitScript(
 
         await initScriptVersion(init.versions, args.verbose)
 
-        const optionInstructions = await initScriptOptions(args, options)
+        const optionResult = await initScriptOptions(args, options)
 
-        await initScriptRename(args, init.rename, args.verbose)
+        await initScriptRename(args, init.rename, args.verbose, optionResult.scopes)
 
         const instructions: string[] = initScriptInstructions(
-          [...optionInstructions, ...(init.instructions ?? [])],
+          [...optionResult.instructions, ...(init.instructions ?? [])],
           args.verbose,
         )
           ?.filter(Boolean)

--- a/src/utils/init-script-options.ts
+++ b/src/utils/init-script-options.ts
@@ -1,10 +1,17 @@
 import { GetArgsResult } from './get-args-result'
-import { initScriptRenameEntries } from './init-script-rename'
+import { initScriptRenameEntryScopes } from './init-script-rename'
 import { InitScriptOptions } from './init-script-schema'
+import { SearchAndReplaceScope } from './search-and-replace'
 
 export interface SelectedTemplateOption {
   name: string
   value: InitScriptOptions[string]
+}
+
+export interface InitScriptOptionsResult {
+  instructions: string[]
+  /** Applied together with the other renames so that no rename rewrites another one's output. */
+  scopes: SearchAndReplaceScope[]
 }
 
 /**
@@ -63,12 +70,16 @@ export function resolveInitScriptOptions(
 }
 
 /**
- * Applies the selected template option transformations and returns their
- * post-create instructions.
+ * Collects the selected template option transformations and their post-create instructions.
  */
-export async function initScriptOptions(args: GetArgsResult, selected: SelectedTemplateOption[]): Promise<string[]> {
+export async function initScriptOptions(
+  args: GetArgsResult,
+  selected: SelectedTemplateOption[],
+): Promise<InitScriptOptionsResult> {
+  const scopes: SearchAndReplaceScope[] = []
   for (const option of selected) {
-    await initScriptRenameEntries(args, option.value.rename)
+    scopes.push(...(await initScriptRenameEntryScopes(args, option.value.rename)))
   }
-  return selected.flatMap((option) => option.value.instructions ?? [])
+
+  return { instructions: selected.flatMap((option) => option.value.instructions ?? []), scopes }
 }

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -4,7 +4,7 @@ import { ensureTargetPath } from './ensure-target-path'
 import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
 import { InitScriptRename, InitScriptRenameEntry } from './init-script-schema'
-import { searchAndReplace } from './search-and-replace'
+import { SearchAndReplaceScope, searchAndReplaceScopes } from './search-and-replace'
 import { namesValues } from './vendor/names'
 
 function compareReplacement(fromA: string, fromB: string): number {
@@ -98,24 +98,29 @@ function initScriptRenameReplacementValues(from: string, to: string): { fromName
   }
 }
 
-async function renameProject(args: GetArgsResult, verbose: boolean) {
+function projectRenameScope(args: GetArgsResult): SearchAndReplaceScope | undefined {
   const { contents } = getPackageJson(args.targetDirectory)
-  if (contents.name) {
-    if (args.verbose) {
-      log.warn(`initScriptRename: renaming template name '${contents.name}' to project name '${args.name}'`)
-    }
-    const { fromNames, toNames } = packageNameReplacementValues(contents.name, args.name)
-    await searchAndReplace(args.targetDirectory, fromNames, toNames, args.dryRun, verbose)
+  if (!contents.name) {
+    return undefined
   }
+  if (args.verbose) {
+    log.warn(`initScriptRename: renaming template name '${contents.name}' to project name '${args.name}'`)
+  }
+  const { fromNames, toNames } = packageNameReplacementValues(contents.name, args.name)
+
+  return { fromStrings: fromNames, path: args.targetDirectory, toStrings: toNames }
 }
 
-export async function initScriptRenameEntries(args: GetArgsResult, rename?: InitScriptRename) {
+export async function initScriptRenameEntryScopes(
+  args: GetArgsResult,
+  rename?: InitScriptRename,
+): Promise<SearchAndReplaceScope[]> {
   const tag = `initScriptRename`
   if (!rename) {
     if (args.verbose) {
       log.warn(`${tag}: no renames found`)
     }
-    return
+    return []
   }
 
   const deprecated = Object.keys(rename).filter((from) => rename[from].paths)
@@ -124,6 +129,8 @@ export async function initScriptRenameEntries(args: GetArgsResult, rename?: Init
       `${tag}: 'paths' is deprecated and is removed in the next major version, use 'in' instead: ${deprecated.join(', ')}`,
     )
   }
+
+  const scopes: SearchAndReplaceScope[] = []
 
   for (const from of Object.keys(rename)) {
     const to = rename[from].to.replace('{{name}}', args.name)
@@ -138,27 +145,44 @@ export async function initScriptRenameEntries(args: GetArgsResult, rename?: Init
       if (args.verbose) {
         log.warn(`${tag}: ${targetPath} -> ${fromNames.join('|')} -> ${toNames.join('|')}`)
       }
-      await searchAndReplace(targetPath, fromNames, toNames, args.dryRun, args.verbose)
+      scopes.push({ fromStrings: fromNames, path: targetPath, toStrings: toNames })
     }
   }
 
-  if (args.verbose) {
-    log.warn(`${tag}: done`)
-  }
+  return scopes
 }
 
-export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
+export async function initScriptRename(
+  args: GetArgsResult,
+  rename?: InitScriptRename,
+  verbose = false,
+  optionScopes: SearchAndReplaceScope[] = [],
+) {
+  const tag = `initScriptRename`
   const { contents } = getPackageJson(args.targetDirectory)
-  await renameProject(args, verbose)
+  let entries = rename
 
   if (contents.name && rename?.[contents.name]) {
     const { [contents.name]: _packageName, ...remainingRename } = rename
     if (args.verbose) {
-      log.warn(`initScriptRename: skipping rename for '${contents.name}' as it matches package.json name`)
+      log.warn(`${tag}: skipping rename for '${contents.name}' as it matches package.json name`)
     }
-    await initScriptRenameEntries(args, remainingRename)
-    return
+    entries = remainingRename
   }
 
-  await initScriptRenameEntries(args, rename)
+  const projectScope = projectRenameScope(args)
+  const scopes = [
+    ...(projectScope ? [projectScope] : []),
+    ...(await initScriptRenameEntryScopes(args, entries)),
+    // Last so that a term selected by a template option wins over the same term in `rename`
+    ...optionScopes,
+  ]
+
+  // Every scope is applied in a single pass per file so that one rename never rewrites the output
+  // of another. See https://github.com/solana-foundation/create-solana-dapp/issues/193
+  await searchAndReplaceScopes(scopes, args.dryRun, args.verbose || verbose)
+
+  if (rename && args.verbose) {
+    log.warn(`${tag}: done`)
+  }
 }

--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -1,10 +1,42 @@
 import { lstat, readdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, relative, resolve, sep } from 'node:path'
 
 const EXCLUDED_DIRECTORIES = new Set(['dist', 'coverage', 'node_modules', '.git', 'tmp'])
 
+/** A set of substitutions and the file or directory they apply to. */
+export interface SearchAndReplaceScope {
+  fromStrings: string[]
+  path: string
+  toStrings: string[]
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+}
+
+/**
+ * Combine every substitution into a single alternation so that each match is taken from the
+ * original value. Replacing one term at a time feeds the output of one substitution into the next,
+ * which compounds any replacement value that contains the term it replaces.
+ * See https://github.com/solana-foundation/create-solana-dapp/issues/193
+ */
+function createReplacer(replacements: Map<string, string>): (value: string) => string {
+  // Longest first so the most specific term wins when two terms match in the same position
+  const searchValues = [...replacements.keys()]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length || a.localeCompare(b))
+
+  if (searchValues.length === 0) {
+    return (value) => value
+  }
+
+  const regex = new RegExp(searchValues.map((value) => escapeRegExp(value)).join('|'), 'g')
+
+  return (value) => value.replace(regex, (match) => replacements.get(match) ?? match)
+}
+
+function isWithinPath(parent: string, child: string): boolean {
+  return child === parent || child.startsWith(parent.endsWith(sep) ? parent : `${parent}${sep}`)
 }
 
 export async function searchAndReplace(
@@ -14,22 +46,55 @@ export async function searchAndReplace(
   isDryRun: boolean = false,
   isVerbose: boolean = false,
 ): Promise<void> {
-  if (fromStrings.length !== toStrings.length) {
-    throw new Error('fromStrings and toStrings arrays must have the same length')
+  await searchAndReplaceScopes([{ fromStrings, path: rootFolder, toStrings }], isDryRun, isVerbose)
+}
+
+export async function searchAndReplaceScopes(
+  scopes: SearchAndReplaceScope[],
+  isDryRun: boolean = false,
+  isVerbose: boolean = false,
+): Promise<void> {
+  for (const scope of scopes) {
+    if (scope.fromStrings.length !== scope.toStrings.length) {
+      throw new Error('fromStrings and toStrings arrays must have the same length')
+    }
+  }
+
+  const resolvedScopes = scopes.map((scope) => ({ ...scope, path: resolve(scope.path) }))
+
+  /**
+   * Every substitution that applies to a path, from the widest scope to the narrowest, so that a
+   * scope targeting an individual file wins over one targeting the whole project.
+   */
+  function replacementsFor(path: string): Map<string, string> {
+    const replacements = new Map<string, string>()
+
+    for (const scope of resolvedScopes
+      .filter((scope) => isWithinPath(scope.path, path))
+      .sort((a, b) => a.path.length - b.path.length)) {
+      for (const [index, fromString] of scope.fromStrings.entries()) {
+        if (fromString) {
+          replacements.set(fromString, scope.toStrings[index])
+        }
+      }
+    }
+
+    return replacements
   }
 
   async function processFile(filePath: string): Promise<void> {
+    const replacements = replacementsFor(filePath)
+    if (replacements.size === 0) {
+      return
+    }
+
     try {
       const content = await readFile(filePath, 'utf8')
-      let newContent = content
+      let newContent = createReplacer(replacements)(content)
 
-      for (const [i, fromString] of fromStrings.entries()) {
-        const regex = new RegExp(escapeRegExp(fromString), 'g')
-        newContent = newContent.replace(regex, () => toStrings[i])
-        // Make sure we maintain the possible newline at the end of the file
-        if (content.endsWith('\n') && !newContent.endsWith('\n')) {
-          newContent += '\n'
-        }
+      // Make sure we maintain the possible newline at the end of the file
+      if (content.endsWith('\n') && !newContent.endsWith('\n')) {
+        newContent += '\n'
       }
 
       if (content !== newContent) {
@@ -38,11 +103,11 @@ export async function searchAndReplace(
         }
         if (isVerbose) {
           console.log(`${isDryRun ? '[Dry Run] ' : ''}File modified: ${filePath}`)
-        }
-        for (const [index, fromStr] of fromStrings.entries()) {
-          const count = (newContent.match(new RegExp(escapeRegExp(toStrings[index]), 'g')) || []).length
-          if (count > 0 && isVerbose) {
-            console.log(`  Replaced "${fromStr}" with "${toStrings[index]}" ${count} time(s)`)
+          for (const [fromString, toString] of replacements) {
+            const count = (newContent.match(new RegExp(escapeRegExp(toString), 'g')) || []).length
+            if (count > 0) {
+              console.log(`  Replaced "${fromString}" with "${toString}" ${count} time(s)`)
+            }
           }
         }
       }
@@ -84,7 +149,11 @@ export async function searchAndReplace(
     }
   }
 
-  async function renamePaths(directoryPath: string): Promise<void> {
+  /**
+   * Renames happen after the contents are replaced, so entries are matched on the path they had
+   * before any of their parent directories were renamed.
+   */
+  async function renamePaths(directoryPath: string, originalDirectoryPath: string): Promise<void> {
     try {
       const entries = await readdir(directoryPath, { withFileTypes: true })
 
@@ -97,12 +166,8 @@ export async function searchAndReplace(
         }
 
         const oldPath = join(directoryPath, entry.name)
-        let newName = entry.name
-
-        for (const [i, fromString] of fromStrings.entries()) {
-          newName = newName.replace(new RegExp(escapeRegExp(fromString), 'g'), () => toStrings[i])
-        }
-
+        const originalPath = join(originalDirectoryPath, entry.name)
+        const newName = createReplacer(replacementsFor(originalPath))(entry.name)
         const newPath = join(directoryPath, newName)
 
         if (oldPath !== newPath) {
@@ -115,7 +180,7 @@ export async function searchAndReplace(
         }
 
         if (entry.isDirectory()) {
-          await renamePaths(entry.isDirectory() ? newPath : oldPath)
+          await renamePaths(isDryRun ? oldPath : newPath, originalPath)
         }
       }
     } catch (error) {
@@ -123,22 +188,41 @@ export async function searchAndReplace(
     }
   }
 
-  try {
-    const rootStats = await lstat(rootFolder)
-    if (rootStats.isFile()) {
-      await processFile(rootFolder)
-      if (isVerbose) {
-        console.log(isDryRun ? 'Dry run completed' : 'Search and replace completed')
-      }
-      return
-    }
+  /** Whether a walk starting at `parent` reaches `child` without entering an excluded directory. */
+  function isReachableFrom(parent: string, child: string): boolean {
+    return relative(parent, child)
+      .split(sep)
+      .every((segment) => !EXCLUDED_DIRECTORIES.has(segment))
+  }
 
-    await processDirectory(rootFolder)
-    await renamePaths(rootFolder)
-    if (isVerbose) {
-      console.log(isDryRun ? 'Dry run completed' : 'Search and replace completed')
+  /**
+   * Walk each scope that is not already covered by a wider one, so no file is visited twice. A
+   * scope inside an excluded directory keeps its own walk: explicitly targeting a path opts it in,
+   * while the wider walk still skips the excluded directory.
+   */
+  const rootPaths = [...new Set(resolvedScopes.map((scope) => scope.path))].filter(
+    (path, _index, paths) =>
+      !paths.some((other) => other !== path && isWithinPath(other, path) && isReachableFrom(other, path)),
+  )
+
+  for (const rootPath of rootPaths) {
+    // Each scope is walked on its own so that an unreadable one does not skip the others
+    try {
+      const rootStats = await lstat(rootPath)
+
+      if (rootStats.isFile()) {
+        await processFile(rootPath)
+        continue
+      }
+
+      await processDirectory(rootPath)
+      await renamePaths(rootPath, rootPath)
+    } catch (error) {
+      console.error('An error occurred:', error)
     }
-  } catch (error) {
-    console.error('An error occurred:', error)
+  }
+
+  if (isVerbose) {
+    console.log(isDryRun ? 'Dry run completed' : 'Search and replace completed')
   }
 }

--- a/test/create-app-task-run-init-script.test.ts
+++ b/test/create-app-task-run-init-script.test.ts
@@ -39,7 +39,7 @@ describe('createAppTaskRunInitScript', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    vi.mocked(initScriptOptions).mockResolvedValue(['Option instruction'])
+    vi.mocked(initScriptOptions).mockResolvedValue({ instructions: ['Option instruction'], scopes: [] })
   })
 
   it('is skipped when the init script is skipped', () => {
@@ -64,7 +64,7 @@ describe('createAppTaskRunInitScript', () => {
     const value = await result.task((input) => input)
 
     expect(initScriptVersion).toHaveBeenCalledWith(init.versions, false)
-    expect(initScriptRename).toHaveBeenCalledWith(args, init.rename, false)
+    expect(initScriptRename).toHaveBeenCalledWith(args, init.rename, false, [])
     expect(initScriptDelete).toHaveBeenCalledWith(args)
     expect(value).toEqual({
       instructions: ['Option instruction', 'Run pnpm install'],

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GetArgsResult } from '../src/utils/get-args-result'
 import { initScriptOptions, resolveInitScriptOptions } from '../src/utils/init-script-options'
-import { initScriptRenameEntries } from '../src/utils/init-script-rename'
+import { initScriptRenameEntryScopes } from '../src/utils/init-script-rename'
 import { InitScriptOptions } from '../src/utils/init-script-schema'
 
 vi.mock('../src/utils/init-script-rename', () => ({
-  initScriptRenameEntries: vi.fn(),
+  initScriptRenameEntryScopes: vi.fn(),
 }))
 
 const options: InitScriptOptions = {
@@ -63,10 +63,13 @@ describe('initScriptOptions', () => {
     vi.clearAllMocks()
   })
 
-  it('applies selected renames and returns selected instructions', async () => {
-    const instructions = await initScriptOptions(args, resolveInitScriptOptions(options, ['llamacpp']))
+  it('collects selected renames and returns selected instructions', async () => {
+    const scope = { fromStrings: ['__MODEL__'], path: '/template/request.json', toStrings: ['local-model'] }
+    vi.mocked(initScriptRenameEntryScopes).mockResolvedValue([scope])
 
-    expect(initScriptRenameEntries).toHaveBeenCalledWith(expect.any(Object), options.llamacpp.rename)
-    expect(instructions).toEqual(['Start llama.cpp'])
+    const result = await initScriptOptions(args, resolveInitScriptOptions(options, ['llamacpp']))
+
+    expect(initScriptRenameEntryScopes).toHaveBeenCalledWith(expect.any(Object), options.llamacpp.rename)
+    expect(result).toEqual({ instructions: ['Start llama.cpp'], scopes: [scope] })
   })
 })

--- a/test/init-script-rename-files.test.ts
+++ b/test/init-script-rename-files.test.ts
@@ -1,0 +1,107 @@
+// test/init-script-rename-files.test.ts
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptRename } from '../src/utils/init-script-rename'
+import { InitScriptRename } from '../src/utils/init-script-schema'
+
+vi.mock('@clack/prompts', () => ({ log: { error: vi.fn(), warn: vi.fn() } }))
+
+// Mirrors the layout of the `counter` templates from https://github.com/solana-foundation/templates
+const templateName = 'gill-next-tailwind-counter'
+const templateRename: InitScriptRename = { counter: { in: ['anchor', 'src'], to: '{{name}}' } }
+
+async function listFiles(directory: string, root = directory): Promise<string[]> {
+  const files: string[] = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const fullPath = join(directory, entry.name)
+    files.push(...(entry.isDirectory() ? await listFiles(fullPath, root) : [relative(root, fullPath)]))
+  }
+  return files.sort()
+}
+
+describe('initScriptRename on the file system', () => {
+  let tempDir: string
+
+  async function writePackageJson(rename: InitScriptRename) {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      `${JSON.stringify({ 'create-solana-dapp': { rename }, name: templateName }, undefined, 2)}\n`,
+    )
+  }
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'init-script-rename-'))
+    await mkdir(join(tempDir, 'anchor/programs/counter/src'), { recursive: true })
+    await mkdir(join(tempDir, 'src/components/counter'), { recursive: true })
+    await writePackageJson(templateRename)
+    await writeFile(join(tempDir, 'anchor/programs/counter/Cargo.toml'), '[package]\nname = "counter"\n')
+    await writeFile(join(tempDir, 'anchor/programs/counter/src/lib.rs'), '#[program]\npub mod counter {}\n')
+    await writeFile(
+      join(tempDir, 'src/components/counter/counter-ui.tsx'),
+      "import { useCounterProgram } from './counter-data-access'\n\nexport function CounterCreate() {}\n",
+    )
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { force: true, recursive: true })
+  })
+
+  function argsFor(name: string): GetArgsResult {
+    return {
+      app: { name: 'create-solana-dapp', version: '0.0.0' },
+      dryRun: false,
+      name,
+      packageManager: 'pnpm',
+      skipGit: false,
+      skipInit: false,
+      skipInstall: false,
+      targetDirectory: tempDir,
+      template: { description: templateName, name: templateName, repository: templateName },
+      verbose: false,
+    }
+  }
+
+  it('should rename a template term that the project name contains', async () => {
+    // https://github.com/solana-foundation/create-solana-dapp/issues/193
+    // The project name contains the template term `counter`, so every replacement value contains
+    // the search term. Nothing may be replaced twice.
+    await initScriptRename(argsFor('mycountergill'), templateRename)
+
+    expect(await listFiles(tempDir)).toStrictEqual([
+      'anchor/programs/mycountergill/Cargo.toml',
+      'anchor/programs/mycountergill/src/lib.rs',
+      'package.json',
+      'src/components/mycountergill/mycountergill-ui.tsx',
+    ])
+    expect(await readFile(join(tempDir, 'src/components/mycountergill/mycountergill-ui.tsx'), 'utf8')).toBe(
+      "import { useMycountergillProgram } from './mycountergill-data-access'\n\nexport function MycountergillCreate() {}\n",
+    )
+  })
+
+  it('should apply overlapping rename scopes in a single pass', async () => {
+    // The package.json rename covers the whole project and this entry covers package.json again.
+    // The template name contains the entry term, so the entry must not rewrite what the
+    // package.json rename already replaced.
+    const rename: InitScriptRename = { counter: { in: ['anchor', 'package.json'], to: '{{name}}' } }
+    await writePackageJson(rename)
+
+    await initScriptRename(argsFor('mycountergill'), rename)
+
+    const contents = JSON.parse(await readFile(join(tempDir, 'package.json'), 'utf8'))
+    expect(contents.name).toBe('mycountergill')
+    expect(await readFile(join(tempDir, 'anchor/programs/mycountergill/Cargo.toml'), 'utf8')).toBe(
+      '[package]\nname = "mycountergill"\n',
+    )
+  })
+
+  it('should rename a template term that a project name does not contain', async () => {
+    await initScriptRename(argsFor('journal'), templateRename)
+
+    expect(await readFile(join(tempDir, 'src/components/journal/journal-ui.tsx'), 'utf8')).toBe(
+      "import { useJournalProgram } from './journal-data-access'\n\nexport function JournalCreate() {}\n",
+    )
+  })
+})

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -4,7 +4,7 @@ import { ensureTargetPath } from '../src/utils/ensure-target-path'
 import { GetArgsResult } from '../src/utils/get-args-result'
 import { getPackageJson } from '../src/utils/get-package-json'
 import { initScriptRename } from '../src/utils/init-script-rename'
-import { searchAndReplace } from '../src/utils/search-and-replace'
+import { searchAndReplaceScopes } from '../src/utils/search-and-replace'
 import { namesValues } from '../src/utils/vendor/names'
 
 vi.mock('../src/utils/ensure-target-path')
@@ -22,6 +22,11 @@ describe('initScriptRename', () => {
   const packageJsonName = 'foo-bar'
 
   const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  /** All renames are handed to `searchAndReplaceScopes` in one call, so each entry is a scope. */
+  function projectScope(toStrings: string[]) {
+    return { fromStrings: ['FooBar', 'foo-bar', 'foo_bar', 'foobar'], path: '/template', toStrings }
+  }
 
   beforeEach(() => {
     vi.resetAllMocks()
@@ -54,10 +59,8 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args)
 
-    expect(searchAndReplace).toHaveBeenCalledWith(
-      args.targetDirectory,
-      ['FooBar', 'foo-bar', 'foo_bar', 'foobar'],
-      ['MyApp', 'my-app', 'my_app', 'myapp'],
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      [projectScope(['MyApp', 'my-app', 'my_app', 'myapp'])],
       false,
       false,
     )
@@ -78,10 +81,14 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args, rename)
 
-    expect(searchAndReplace).toHaveBeenLastCalledWith(
-      '/template/app.json',
-      fromNames,
-      ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'My Unicorn2', 'myUnicorn2'],
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          fromStrings: fromNames,
+          path: '/template/app.json',
+          toStrings: ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'My Unicorn2', 'myUnicorn2'],
+        },
+      ]),
       false,
       false,
     )
@@ -102,10 +109,14 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args, rename)
 
-    expect(searchAndReplace).toHaveBeenLastCalledWith(
-      '/template/app.json',
-      ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp'],
-      ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'My Unicorn2', 'myUnicorn2'],
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          fromStrings: ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp'],
+          path: '/template/app.json',
+          toStrings: ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'My Unicorn2', 'myUnicorn2'],
+        },
+      ]),
       false,
       false,
     )
@@ -128,10 +139,14 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args, rename)
 
-    expect(searchAndReplace).toHaveBeenLastCalledWith(
-      '/template/request.json',
-      ['InferenceModel', 'INFERENCE_MODEL', 'inference-model', 'inferenceModel'],
-      ['Qwen306b', 'QWEN306B', 'qwen3:0.6b', 'qwen306b'],
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          fromStrings: ['InferenceModel', 'INFERENCE_MODEL', 'inference-model', 'inferenceModel'],
+          path: '/template/request.json',
+          toStrings: ['Qwen306b', 'QWEN306B', 'qwen3:0.6b', 'qwen306b'],
+        },
+      ]),
       false,
       false,
     )
@@ -142,10 +157,8 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args)
 
-    expect(searchAndReplace).toHaveBeenCalledWith(
-      args.targetDirectory,
-      expect.any(Array),
-      expect.any(Array),
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      [expect.objectContaining({ path: args.targetDirectory })],
       true,
       false,
     )
@@ -156,8 +169,25 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args, undefined)
 
-    expect(searchAndReplace).toHaveBeenCalledTimes(1)
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      [projectScope(['TestProject', 'test-project', 'test_project', 'testproject'])],
+      false,
+      false,
+    )
     expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('should apply template option renames in the same pass, after the rename entries', async () => {
+    const args = { ...baseArgs }
+    const rename = { example: { in: ['some/path/to/file'], to: '{{name}}Example' } }
+    const optionScope = { fromStrings: ['__MODEL__'], path: '/template/request.json', toStrings: ['qwen3:0.6b'] }
+    vi.mocked(namesValues).mockReturnValue(['Example'])
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename, false, [optionScope])
+
+    expect(searchAndReplaceScopes).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(searchAndReplaceScopes).mock.calls[0][0].at(-1)).toStrictEqual(optionScope)
   })
 
   it('should perform search and replace based on rename instructions', async () => {
@@ -175,10 +205,10 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args, rename)
 
-    expect(searchAndReplace).toHaveBeenCalledWith(
-      expect.stringContaining('some/path/to/file'),
-      exampleNames,
-      newNameExamples,
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        { fromStrings: exampleNames, path: '/template/some/path/to/file', toStrings: newNameExamples },
+      ]),
       args.dryRun,
       args.verbose,
     )
@@ -199,10 +229,10 @@ describe('initScriptRename', () => {
 
     await initScriptRename(args, rename)
 
-    expect(searchAndReplace).toHaveBeenCalledWith(
-      expect.stringContaining('some/path/to/file'),
-      exampleNames,
-      newNameExamples,
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        { fromStrings: exampleNames, path: '/template/some/path/to/file', toStrings: newNameExamples },
+      ]),
       args.dryRun,
       args.verbose,
     )
@@ -270,7 +300,11 @@ describe('initScriptRename', () => {
     await initScriptRename(args, rename)
 
     expect(log.error).toHaveBeenCalledWith(`initScriptRename: target does not exist /template/nonexistent/path/to/file`)
-    //been called once for the package.json rename
-    expect(searchAndReplace).toHaveBeenCalledTimes(1)
+    // Only the package.json rename is left, the nonexistent path does not become a scope
+    expect(searchAndReplaceScopes).toHaveBeenCalledWith(
+      [expect.objectContaining({ path: args.targetDirectory })],
+      false,
+      true,
+    )
   })
 })

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -1,10 +1,10 @@
 // test/search-and-replace.test.ts
 import mockFs from 'mock-fs'
-import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { searchAndReplace } from '../src/utils/search-and-replace'
+import { searchAndReplace, searchAndReplaceScopes } from '../src/utils/search-and-replace'
 
 describe('searchAndReplace', () => {
   let tempDir: string
@@ -72,6 +72,118 @@ describe('searchAndReplace', () => {
     expect(await readFile(join(tempDir, 'baz.txt'), 'utf8')).toBe('baz fooXbar')
     expect(await readFile(join(tempDir, 'fooXbar.txt'), 'utf8')).toBe('fooXbar')
     await expect(access(join(tempDir, 'foo.bar.txt'))).rejects.toThrow()
+  })
+
+  it('should not replace inside text it just replaced', async () => {
+    // https://github.com/solana-foundation/create-solana-dapp/issues/193
+    // The template term is `counter` and the project is named `mycountergill`, so every
+    // replacement value contains the term we are searching for. Each substitution must be
+    // applied to the original content only, never to the output of an earlier substitution.
+    await writeFile(join(tempDir, 'counter-ui.tsx'), "import { useCounterProgram } from './counter-data-access'\n")
+
+    await searchAndReplace(
+      tempDir,
+      ['Counter', 'COUNTER', 'counter'],
+      ['Mycountergill', 'MYCOUNTERGILL', 'mycountergill'],
+    )
+
+    expect(await readFile(join(tempDir, 'mycountergill-ui.tsx'), 'utf8')).toBe(
+      "import { useMycountergillProgram } from './mycountergill-data-access'\n",
+    )
+  })
+
+  it('should apply a duplicated substitution only once', async () => {
+    // `namesValues()` returns five positional variants, and for a single lowercase word three of
+    // them are identical. Repeating a substitution must not compound it.
+    await writeFile(join(tempDir, 'counter.json'), '{"metadata":{"name":"counter"}}\n')
+
+    await searchAndReplace(
+      tempDir,
+      ['counter', 'counter', 'counter'],
+      ['mycountergill', 'mycountergill', 'mycountergill'],
+    )
+
+    expect(await readdir(tempDir)).toContain('mycountergill.json')
+    expect(await readFile(join(tempDir, 'mycountergill.json'), 'utf8')).toBe('{"metadata":{"name":"mycountergill"}}\n')
+  })
+
+  it('should not let one substitution feed the next', async () => {
+    await writeFile(join(tempDir, 'names.txt'), 'counter gill\n')
+
+    await searchAndReplace(tempDir, ['counter', 'gill'], ['counter-gill', 'gill-sdk'])
+
+    expect(await readFile(join(tempDir, 'names.txt'), 'utf8')).toBe('counter-gill gill-sdk\n')
+  })
+
+  it('should prefer the longest match when two search values overlap', async () => {
+    await writeFile(join(tempDir, 'anchor.toml'), 'gill-next-tailwind-counter counter\n')
+
+    await searchAndReplace(
+      tempDir,
+      ['counter', 'gill-next-tailwind-counter'],
+      ['mycountergill', 'mycountergill-workspace'],
+    )
+
+    expect(await readFile(join(tempDir, 'anchor.toml'), 'utf8')).toBe('mycountergill-workspace mycountergill\n')
+  })
+
+  describe('searchAndReplaceScopes', () => {
+    it('should apply overlapping scopes in a single pass', async () => {
+      // The wide scope replaces a value that contains the narrow scope's search value
+      await mkdir(join(tempDir, 'anchor'))
+      await writeFile(join(tempDir, 'package.json'), '{"name":"gill-next-tailwind-counter"}\n')
+      await writeFile(join(tempDir, 'anchor', 'Anchor.toml'), 'counter = "..."\n')
+
+      await searchAndReplaceScopes([
+        { fromStrings: ['gill-next-tailwind-counter'], path: tempDir, toStrings: ['mycountergill'] },
+        { fromStrings: ['counter'], path: join(tempDir, 'package.json'), toStrings: ['mycountergill'] },
+      ])
+
+      expect(await readFile(join(tempDir, 'package.json'), 'utf8')).toBe('{"name":"mycountergill"}\n')
+      expect(await readFile(join(tempDir, 'anchor', 'Anchor.toml'), 'utf8')).toBe('counter = "..."\n')
+    })
+
+    it('should let the narrowest scope win for the same search value', async () => {
+      await mkdir(join(tempDir, 'app'))
+      await writeFile(join(tempDir, 'app', 'model.json'), '{"model":"__MODEL__"}\n')
+      await writeFile(join(tempDir, 'root.json'), '{"model":"__MODEL__"}\n')
+
+      await searchAndReplaceScopes([
+        { fromStrings: ['__MODEL__'], path: tempDir, toStrings: ['default-model'] },
+        { fromStrings: ['__MODEL__'], path: join(tempDir, 'app'), toStrings: ['selected-model'] },
+      ])
+
+      expect(await readFile(join(tempDir, 'app', 'model.json'), 'utf8')).toBe('{"model":"selected-model"}\n')
+      expect(await readFile(join(tempDir, 'root.json'), 'utf8')).toBe('{"model":"default-model"}\n')
+    })
+
+    it('should process a scope that explicitly targets a path inside an excluded directory', async () => {
+      await mkdir(join(tempDir, 'tmp'))
+      await writeFile(join(tempDir, 'tmp', 'config.json'), 'Hello excluded')
+
+      await searchAndReplaceScopes([
+        { fromStrings: ['Hello'], path: tempDir, toStrings: ['Hi'] },
+        { fromStrings: ['Hello'], path: join(tempDir, 'tmp', 'config.json'), toStrings: ['Hey'] },
+      ])
+
+      // The explicit scope opts the excluded path in, and the narrower scope wins
+      expect(await readFile(join(tempDir, 'tmp', 'config.json'), 'utf8')).toBe('Hey excluded')
+      expect(await readFile(join(tempDir, 'file1.txt'), 'utf8')).toBe('Hi world')
+    })
+
+    it('should keep replacing other scopes when one does not exist', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await searchAndReplaceScopes([
+        { fromStrings: ['Hello'], path: join(tempDir, 'missing'), toStrings: ['Hi'] },
+        { fromStrings: ['Hello'], path: join(tempDir, 'file1.txt'), toStrings: ['Hi'] },
+      ])
+
+      expect(await readFile(join(tempDir, 'file1.txt'), 'utf8')).toBe('Hi world')
+      expect(consoleErrorSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error))
+
+      consoleErrorSpy.mockRestore()
+    })
   })
 
   it('should exclude directories like node_modules and .git from processing', async () => {


### PR DESCRIPTION
## Why

Replacing one search term at a time re-scanned the output of earlier substitutions, so a project name containing a template term compounded on every pass: naming a counter-template project `mycountergill` produced `mymymycountergillgillgill` in program names, file names, and the IDL path the setup script then failed to resolve. The same compounding existed across calls — the package.json project rename, each rename entry, and template option renames each walked overlapping trees in sequence, so even a single-pass replacement per call would still re-scan what a previous call wrote.

## What

- `searchAndReplace` combines all substitutions into one alternation regex (longest match first) and applies them in a single pass over each file's contents and name, so no replacement output is ever re-matched
- New `searchAndReplaceScopes` applies multiple rename sources together: substitutions are unioned per file, with the narrowest scope winning on conflicting terms
- `initScriptRename` collects the project rename and all rename entries as scopes and applies them in one call
- `initScriptOptions` returns its rename scopes instead of applying them, and `initScriptRename` folds them into the same pass after the entry scopes
- An unreadable scope root logs and continues instead of aborting the remaining scopes, and dry runs no longer recurse into directories under the paths they only pretended to rename
- New file-system-level test suite (`test/init-script-rename-files.test.ts`) reproduces the issue scenario end to end, plus unit tests for compounding, duplicated substitutions, scope precedence, and error isolation

## Notes

Verified against the real CLI with live templates using hostile names (`my-scaffold-counter` on `kit/nextjs`, `counter-scaffold` on `web3js/web3js-next-tailwind-counter`) — no doubling in either. Two known issues are intentionally out of scope: a single lowercase rename term still maps to its kebab form in Rust contexts (`pub mod my-counter`), and the project-wide rename rewrites the template's own README install command; both predate this change.

Fixes #192, fixes #193
