### PR TITLE
fix: publish canary releases with the calculated next version instead of 0.0.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   ],
   "commit": false,
   "linked": [],
+  "snapshot": {
+    "useCalculatedVersion": true
+  },
   "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
Canary snapshots were published as `0.0.0-canary-<timestamp>`, which hides which release the canary previews. With `snapshot.useCalculatedVersion` the pending changesets are applied first, so a canary now reads e.g. `4.9.0-canary-<timestamp>`.

<img width="658" height="387" alt="image" src="https://github.com/user-attachments/assets/c491bcd5-460e-42ed-8e0e-07d449482d1e" />
