### PR TITLE
fix: remove stale bun.lockb lockfile during install

### DIFF
--- a/src/utils/create-app-task-install-dependencies.ts
+++ b/src/utils/create-app-task-install-dependencies.ts
@@ -16,7 +16,7 @@ export function createAppTaskInstallDependencies(args: GetArgsResult): Task {
       if (args.verbose) {
         log.warn(`Installing via ${pm}`)
       }
-      const deleteLockFiles = ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lock']
+      const deleteLockFiles = ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lock', 'bun.lockb']
         // We don't want to delete the lock file for the current package manager
         .filter((item) => item !== lockFile)
         // We only want to delete the lock file if it exists

--- a/src/utils/create-app-task-install-dependencies.ts
+++ b/src/utils/create-app-task-install-dependencies.ts
@@ -18,7 +18,7 @@ export function createAppTaskInstallDependencies(args: GetArgsResult): Task {
       }
       const deleteLockFiles = ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lock', 'bun.lockb']
         // We don't want to delete the lock file for the current package manager
-        .filter((item) => item !== lockFile)
+        .filter((item) => item !== lockFile && !(pm === 'bun' && item === 'bun.lockb'))
         // We only want to delete the lock file if it exists
         .filter((item) => existsSync(join(args.targetDirectory, item)))
 

--- a/test/create-app-task-install-dependencies.test.ts
+++ b/test/create-app-task-install-dependencies.test.ts
@@ -52,6 +52,28 @@ describe('createAppTaskInstallDependencies', () => {
     expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
   })
 
+  it("removes Bun's legacy binary lockfile (bun.lockb)", async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    const selectedLockFile = join(targetDirectory, 'package-lock.json')
+    const staleLockFile = join(targetDirectory, 'bun.lockb')
+    await Promise.all([writeFile(selectedLockFile, ''), writeFile(staleLockFile, '')])
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await task.task((value) => value)
+
+    expect(existsSync(selectedLockFile)).toBe(true)
+    expect(existsSync(staleLockFile)).toBe(false)
+    expect(execAndWait).toHaveBeenCalledOnce()
+    expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
+  })
+
   it('continues installation when a stale lockfile disappears before removal', async () => {
     const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
     temporaryDirectories.push(targetDirectory)

--- a/test/create-app-task-install-dependencies.test.ts
+++ b/test/create-app-task-install-dependencies.test.ts
@@ -74,6 +74,26 @@ describe('createAppTaskInstallDependencies', () => {
     expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
   })
 
+  it("preserves Bun's legacy binary lockfile when Bun is selected", async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    const legacyLockFile = join(targetDirectory, 'bun.lockb')
+    await writeFile(legacyLockFile, '')
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'bun',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await task.task((value) => value)
+
+    expect(existsSync(legacyLockFile)).toBe(true)
+    expect(execAndWait).toHaveBeenCalledOnce()
+    expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^bun install /), targetDirectory)
+  })
+
   it('continues installation when a stale lockfile disappears before removal', async () => {
     const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
     temporaryDirectories.push(targetDirectory)

--- a/test/create-app-task-install-dependencies.test.ts
+++ b/test/create-app-task-install-dependencies.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createAppTaskInstallDependencies } from '../src/utils/create-app-task-install-dependencies'
 import type { GetArgsResult } from '../src/utils/get-args-result'
 import { execAndWait } from '../src/utils/vendor/child-process-utils'
+import * as packageManager from '../src/utils/vendor/package-manager'
 
 const mockedFs = vi.hoisted(() => ({ disappearingPath: undefined as string | undefined }))
 
@@ -79,6 +80,12 @@ describe('createAppTaskInstallDependencies', () => {
     temporaryDirectories.push(targetDirectory)
     const legacyLockFile = join(targetDirectory, 'bun.lockb')
     await writeFile(legacyLockFile, '')
+    vi.spyOn(packageManager, 'getPackageManagerCommand').mockReturnValueOnce({
+      exec: 'bun',
+      globalAdd: 'bun add -g',
+      install: 'bun install --silent',
+      lockFile: 'bun.lock',
+    })
 
     const task = createAppTaskInstallDependencies({
       packageManager: 'bun',


### PR DESCRIPTION
Diagnosed and fixed with AI assistance (Claude). The foreign-lockfile cleanup added in #257 misses Bun's legacy binary lockfile (bun.lockb), so it survives into the generated project; see commit.