### PR TITLE
fix: drop incompatible packageManager field in generated package.json

### DIFF
--- a/.changeset/remove-incompatible-package-manager.md
+++ b/.changeset/remove-incompatible-package-manager.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Remove the template's `packageManager` field before install when it does not match the effective package manager (template-configured package managers take precedence)

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -1,3 +1,5 @@
+import { log } from '@clack/prompts'
+import { existsSync } from 'node:fs'
 import { createAppTaskCloneTemplate } from './create-app-task-clone-template'
 import { createAppTaskInitializeGit } from './create-app-task-initialize-git'
 import { createAppTaskInstallDependencies } from './create-app-task-install-dependencies'
@@ -5,7 +7,9 @@ import { createAppTaskInstallDevSkill } from './create-app-task-install-dev-skil
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
+import { getPackageJsonPath } from './get-package-json-path'
 import { initScriptPackageManager } from './init-script-package-manager'
+import { removeIncompatiblePackageManager } from './remove-incompatible-package-manager'
 import { tasks } from './vendor/clack-tasks'
 
 export type CreateAppArgs = GetArgsResult
@@ -18,6 +22,21 @@ export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
   ])
 
   initScriptPackageManager(args)
+
+  // Remove an incompatible `packageManager` field from the template's
+  // package.json so the effective package manager can install. This runs
+  // AFTER initScriptPackageManager so a template-configured package manager
+  // takes precedence: args.packageManager already reflects the template's
+  // choice here, and a matching pin is left in place. Runs during setup so
+  // it applies even when install is skipped.
+  if (existsSync(getPackageJsonPath(args.targetDirectory))) {
+    const removedPackageManager = removeIncompatiblePackageManager(args.targetDirectory, args.packageManager)
+    if (removedPackageManager) {
+      log.warn(
+        `Removed \`packageManager\` (${removedPackageManager}) from package.json as it does not match the selected package manager (${args.packageManager}); this may indicate potential incompatibilities with the template.`,
+      )
+    }
+  }
 
   return [
     ...instructions,

--- a/src/utils/get-package-json.ts
+++ b/src/utils/get-package-json.ts
@@ -27,6 +27,7 @@ const PackageJsonSchema = z
   .object({
     [initScriptKey]: InitScriptSchema.optional(),
     name: z.string().optional(),
+    packageManager: z.string().optional(),
     scripts: z.record(z.string()).optional(),
   })
   .passthrough()

--- a/src/utils/remove-incompatible-package-manager.ts
+++ b/src/utils/remove-incompatible-package-manager.ts
@@ -1,0 +1,36 @@
+import { writeFileSync } from 'node:fs'
+import { getPackageJson } from './get-package-json'
+import { PackageManager } from './vendor/package-manager'
+
+/**
+ * Removes the `packageManager` field from the generated app's `package.json`
+ * when it does not match the selected package manager.
+ *
+ * Templates can pin a `packageManager` (e.g. `pnpm@10.15.1`). Managers such as
+ * pnpm and yarn error when they encounter an incompatible value, so a template
+ * that pins a different manager than the one the user selected would otherwise
+ * break installation (see #100).
+ *
+ * @param targetDirectory - The directory containing the generated app's `package.json`.
+ * @param packageManager - The package manager the user selected.
+ * @returns The removed `packageManager` value, or `undefined` if nothing was removed.
+ */
+export function removeIncompatiblePackageManager(
+  targetDirectory: string,
+  packageManager: PackageManager,
+): string | undefined {
+  const { contents, path } = getPackageJson(targetDirectory)
+  const value = contents.packageManager
+  if (!value) {
+    return undefined
+  }
+  // `packageManager` is formatted as `<name>@<version>` (e.g. `pnpm@10.15.1`).
+  const [name] = value.split('@')
+  if (name === packageManager) {
+    return undefined
+  }
+  const updated = { ...contents }
+  delete updated.packageManager
+  writeFileSync(path, `${JSON.stringify(updated, undefined, 2)}\n`)
+  return value
+}

--- a/test/remove-incompatible-package-manager.test.ts
+++ b/test/remove-incompatible-package-manager.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptPackageManager } from '../src/utils/init-script-package-manager'
+import { initScriptKey } from '../src/utils/init-script-schema'
+import { removeIncompatiblePackageManager } from '../src/utils/remove-incompatible-package-manager'
+
+describe('removeIncompatiblePackageManager', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'csd-pm-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true })
+  })
+
+  function writePackageJson(pkg: Record<string, unknown>) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg, undefined, 2))
+  }
+
+  function readPackageJson(): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+  }
+
+  it('removes `packageManager` when it does not match the selected package manager', () => {
+    writePackageJson({ name: 'demo', packageManager: 'pnpm@10.15.1' })
+    const removed = removeIncompatiblePackageManager(dir, 'npm')
+    expect(removed).toBe('pnpm@10.15.1')
+    expect(readPackageJson()).not.toHaveProperty('packageManager')
+    expect(readPackageJson().name).toBe('demo')
+    // The rewritten file keeps a trailing newline (insert_final_newline).
+    expect(readFileSync(join(dir, 'package.json'), 'utf8').endsWith('\n')).toBe(true)
+  })
+
+  it('keeps `packageManager` when its name matches the selected package manager', () => {
+    writePackageJson({ name: 'demo', packageManager: 'pnpm@10.15.1' })
+    const removed = removeIncompatiblePackageManager(dir, 'pnpm')
+    expect(removed).toBeUndefined()
+    expect(readPackageJson().packageManager).toBe('pnpm@10.15.1')
+  })
+
+  it('does nothing when there is no `packageManager` field', () => {
+    writePackageJson({ name: 'demo' })
+    const removed = removeIncompatiblePackageManager(dir, 'yarn')
+    expect(removed).toBeUndefined()
+    expect(readPackageJson()).not.toHaveProperty('packageManager')
+  })
+})
+
+describe('template-configured package manager precedence (#258)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'csd-pm-precedence-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true })
+  })
+
+  it('keeps a pin matching the template-configured package manager, even when another manager was selected', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify(
+        {
+          [initScriptKey]: { packageManager: 'pnpm' },
+          name: 'demo',
+          packageManager: 'pnpm@10.15.1',
+        },
+        undefined,
+        2,
+      ),
+    )
+    // Mirrors the ordering in createApp: the template override runs first,
+    // then the removal compares against the *effective* package manager.
+    const args = {
+      packageManager: 'npm',
+      packageManagerExplicit: false,
+      targetDirectory: dir,
+    } as GetArgsResult
+    initScriptPackageManager(args)
+    expect(args.packageManager).toBe('pnpm')
+    const removed = removeIncompatiblePackageManager(dir, args.packageManager)
+    expect(removed).toBeUndefined()
+    const contents = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    expect(contents.packageManager).toBe('pnpm@10.15.1')
+  })
+
+  it('still removes a pin that conflicts with the effective package manager when the template configures none', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: 'demo', packageManager: 'yarn@4.0.0' }, undefined, 2),
+    )
+    const args = {
+      packageManager: 'npm',
+      packageManagerExplicit: false,
+      targetDirectory: dir,
+    } as GetArgsResult
+    initScriptPackageManager(args)
+    expect(args.packageManager).toBe('npm')
+    const removed = removeIncompatiblePackageManager(dir, args.packageManager)
+    expect(removed).toBe('yarn@4.0.0')
+  })
+})


### PR DESCRIPTION
## Summary

Removes an incompatible `packageManager` declaration from generated project manifests where it can conflict with the user runtime.

## Why

Generated projects should work out-of-the-box across supported package-manager setups without forcing an invalid tool declaration.
