### PR TITLE
fix(rename): avoid duplicate replacements for package-name variants

### DIFF
--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -48,6 +48,10 @@ function toSnakeName(name: string): string {
   return getNameSegments(name).join('_').toLowerCase()
 }
 
+function toCanonicalName(name: string): string {
+  return getNameSegments(name).join('').toLowerCase()
+}
+
 function renameEntryPaths(entry: InitScriptRenameEntry): string[] {
   // `paths` is the deprecated spelling of `in`; the schema guarantees exactly one of them is set
   return entry.in ?? entry.paths ?? []
@@ -151,14 +155,20 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
   const { contents } = getPackageJson(args.targetDirectory)
   await renameProject(args, verbose)
 
-  if (contents.name && rename?.[contents.name]) {
-    const { [contents.name]: _packageName, ...remainingRename } = rename
-    if (args.verbose) {
-      log.warn(`initScriptRename: skipping rename for '${contents.name}' as it matches package.json name`)
-    }
-    await initScriptRenameEntries(args, remainingRename)
+  if (!contents.name || !rename) {
+    await initScriptRenameEntries(args, rename)
     return
   }
 
-  await initScriptRenameEntries(args, rename)
+  const entries = Object.entries(rename)
+  const skipped = entries.filter(([from]) => toCanonicalName(from) === toCanonicalName(contents.name!))
+  const remainingRename = Object.fromEntries(entries.filter(([from]) => toCanonicalName(from) !== toCanonicalName(contents.name!)))
+
+  if (skipped.length > 0 && args.verbose) {
+    log.warn(
+      `initScriptRename: skipping rename for '${skipped.map(([from]) => from).join(', ')}' as it matches package.json name`,
+    )
+  }
+
+  await initScriptRenameEntries(args, remainingRename)
 }

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -162,7 +162,9 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
 
   const entries = Object.entries(rename)
   const skipped = entries.filter(([from]) => toCanonicalName(from) === toCanonicalName(contents.name!))
-  const remainingRename = Object.fromEntries(entries.filter(([from]) => toCanonicalName(from) !== toCanonicalName(contents.name!)))
+  const remainingRename = Object.fromEntries(
+    entries.filter(([from]) => toCanonicalName(from) !== toCanonicalName(contents.name!)),
+  )
 
   if (skipped.length > 0 && args.verbose) {
     log.warn(

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -48,10 +48,6 @@ function toSnakeName(name: string): string {
   return getNameSegments(name).join('_').toLowerCase()
 }
 
-function toCanonicalName(name: string): string {
-  return getNameSegments(name).join('').toLowerCase()
-}
-
 function renameEntryPaths(entry: InitScriptRenameEntry): string[] {
   // `paths` is the deprecated spelling of `in`; the schema guarantees exactly one of them is set
   return entry.in ?? entry.paths ?? []
@@ -161,10 +157,9 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
   }
 
   const entries = Object.entries(rename)
-  const skipped = entries.filter(([from]) => toCanonicalName(from) === toCanonicalName(contents.name!))
-  const remainingRename = Object.fromEntries(
-    entries.filter(([from]) => toCanonicalName(from) !== toCanonicalName(contents.name!)),
-  )
+  const { fromNames: packageNameVariants } = packageNameReplacementValues(contents.name, args.name)
+  const skipped = entries.filter(([from]) => packageNameVariants.includes(from))
+  const remainingRename = Object.fromEntries(entries.filter(([from]) => !packageNameVariants.includes(from)))
 
   if (skipped.length > 0 && args.verbose) {
     log.warn(

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -292,5 +292,3 @@ describe('initScriptRename', () => {
     expect(searchAndReplace).toHaveBeenCalledTimes(1)
   })
 })
-
-

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -227,6 +227,24 @@ describe('initScriptRename', () => {
     expect(log.warn).not.toHaveBeenCalled()
   })
 
+  it('should skip rename entries that are package name variants', async () => {
+    const args = { ...baseArgs, name: 'my-counter' }
+    const rename = {
+      Counter: {
+        in: ['anchor/programs/counter/src'],
+        to: '{{name}}',
+      },
+    }
+    vi.mocked(getPackageJson).mockReturnValue({
+      contents: { name: 'counter' },
+      path: `${baseArgs.targetDirectory}/package.json`,
+    })
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenCalledTimes(1)
+    expect(namesValues).not.toHaveBeenCalled()
+  })
   it('should log a message when verbose and no rename object is provided', async () => {
     const args: GetArgsResult = { ...baseArgs, verbose: true }
     await initScriptRename(args, undefined)
@@ -274,3 +292,5 @@ describe('initScriptRename', () => {
     expect(searchAndReplace).toHaveBeenCalledTimes(1)
   })
 })
+
+

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -1,4 +1,5 @@
 import { log } from '@clack/prompts'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ensureTargetPath } from '../src/utils/ensure-target-path'
 import { GetArgsResult } from '../src/utils/get-args-result'
@@ -244,6 +245,36 @@ describe('initScriptRename', () => {
 
     expect(searchAndReplace).toHaveBeenCalledTimes(1)
     expect(namesValues).not.toHaveBeenCalled()
+  })
+
+  it('should retain display-name entries not handled by package-name replacement', async () => {
+    const args = { ...baseArgs, name: 'my-project' }
+    const rename = {
+      'Example App': {
+        in: ['README.md'],
+        to: '{{name}}',
+      },
+    }
+    const displayNameValues = ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp']
+    const projectNameValues = ['MyProject', 'MY_PROJECT', 'my-project', 'My Project', 'myProject']
+    vi.mocked(getPackageJson).mockReturnValue({
+      contents: { name: 'example-app' },
+      path: `${baseArgs.targetDirectory}/package.json`,
+    })
+    vi.mocked(namesValues).mockImplementation((name) =>
+      name === 'Example App' ? displayNameValues : projectNameValues,
+    )
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenLastCalledWith(
+      join(baseArgs.targetDirectory, 'README.md'),
+      displayNameValues,
+      projectNameValues,
+      false,
+      false,
+    )
   })
   it('should log a message when verbose and no rename object is provided', async () => {
     const args: GetArgsResult = { ...baseArgs, verbose: true }


### PR DESCRIPTION
## Summary

Prevents duplicate rename passes when an init-script rename key is effectively the same as the template package name but written in a different case/format (for example `Counter` vs `counter`).

This normalizes names before filtering package-name renames, so project-name replacement is applied once.

## Fixes

- Fixes #192

## Validation

- `pnpm vitest run test/init-script-rename.test.ts -t "should skip rename entries that are package name variants"`
