### PR TITLE
fix: apply search and replace in a single pass

### DIFF
--- a/.changeset/single-pass-search-replace.md
+++ b/.changeset/single-pass-search-replace.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Apply search and replace in a single pass so a later rename pair cannot rewrite an earlier one's output. Renaming the `counter` template to `my-counter` produced `my-mycounter` in generated files and paths.

--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -7,6 +7,40 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 }
 
+/**
+ * Build a replacer that applies every `from` -> `to` pair in a single pass.
+ *
+ * Replacing sequentially lets one pair rewrite the output of an earlier pair,
+ * which corrupts names whenever a replacement contains another search string.
+ * Renaming the `counter` template to `my-counter` produced `my-mycounter`,
+ * because the compact variant then matched the `counter` inside the kebab
+ * result. Matching all patterns at once means replaced text is never rescanned.
+ *
+ * Longer search strings are tried first so the most specific pattern wins, and
+ * the first pair for a duplicated search string is the one that applies.
+ */
+function createReplacer(fromStrings: string[], toStrings: string[]): (value: string) => string {
+  const replacements = new Map<string, string>()
+
+  for (const [i, fromString] of fromStrings.entries()) {
+    if (fromString.length > 0 && !replacements.has(fromString)) {
+      replacements.set(fromString, toStrings[i])
+    }
+  }
+
+  if (replacements.size === 0) {
+    return (value) => value
+  }
+
+  const pattern = [...replacements.keys()]
+    .sort((a, b) => b.length - a.length)
+    .map((from) => escapeRegExp(from))
+    .join('|')
+  const regex = new RegExp(pattern, 'g')
+
+  return (value) => value.replace(regex, (match) => replacements.get(match) ?? match)
+}
+
 export async function searchAndReplace(
   rootFolder: string,
   fromStrings: string[],
@@ -18,18 +52,16 @@ export async function searchAndReplace(
     throw new Error('fromStrings and toStrings arrays must have the same length')
   }
 
+  const replace = createReplacer(fromStrings, toStrings)
+
   async function processFile(filePath: string): Promise<void> {
     try {
       const content = await readFile(filePath, 'utf8')
-      let newContent = content
+      let newContent = replace(content)
 
-      for (const [i, fromString] of fromStrings.entries()) {
-        const regex = new RegExp(escapeRegExp(fromString), 'g')
-        newContent = newContent.replace(regex, () => toStrings[i])
-        // Make sure we maintain the possible newline at the end of the file
-        if (content.endsWith('\n') && !newContent.endsWith('\n')) {
-          newContent += '\n'
-        }
+      // Make sure we maintain the possible newline at the end of the file
+      if (content.endsWith('\n') && !newContent.endsWith('\n')) {
+        newContent += '\n'
       }
 
       if (content !== newContent) {
@@ -97,11 +129,7 @@ export async function searchAndReplace(
         }
 
         const oldPath = join(directoryPath, entry.name)
-        let newName = entry.name
-
-        for (const [i, fromString] of fromStrings.entries()) {
-          newName = newName.replace(new RegExp(escapeRegExp(fromString), 'g'), () => toStrings[i])
-        }
+        const newName = replace(entry.name)
 
         const newPath = join(directoryPath, newName)
 

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -116,6 +116,44 @@ describe('searchAndReplace', () => {
     consoleLogSpy.mockRestore()
   })
 
+  it('should not let one replacement rewrite the output of another (#192)', async () => {
+    // Renaming the `counter` template to `my-counter` passes several name
+    // variants, all searching for `counter`. Applied sequentially, the compact
+    // variant matched the `counter` inside the freshly written `my-counter`.
+    await writeFile(join(tempDir, 'lib.rs'), 'declare_id!("counter");')
+
+    await searchAndReplace(tempDir, ['counter', 'counter'], ['my-counter', 'mycounter'])
+
+    const content = await readFile(join(tempDir, 'lib.rs'), 'utf8')
+    expect(content).toBe('declare_id!("my-counter");')
+  })
+
+  it('should not rescan replaced text with later pairs', async () => {
+    await writeFile(join(tempDir, 'chain.txt'), 'foo')
+
+    await searchAndReplace(tempDir, ['foo', 'bar'], ['bar', 'baz'])
+
+    const content = await readFile(join(tempDir, 'chain.txt'), 'utf8')
+    expect(content).toBe('bar')
+  })
+
+  it('should prefer the longest matching search string', async () => {
+    await writeFile(join(tempDir, 'longest.txt'), 'my_counter')
+
+    await searchAndReplace(tempDir, ['counter', 'my_counter'], ['Counter', 'acme_counter'])
+
+    const content = await readFile(join(tempDir, 'longest.txt'), 'utf8')
+    expect(content).toBe('acme_counter')
+  })
+
+  it('should apply single-pass replacement to renamed paths too', async () => {
+    await writeFile(join(tempDir, 'counter.txt'), 'content')
+
+    await searchAndReplace(tempDir, ['counter', 'counter'], ['my-counter', 'mycounter'])
+
+    await expect(access(join(tempDir, 'my-counter.txt'))).resolves.toBeUndefined()
+  })
+
   it('should handle errors gracefully', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 


### PR DESCRIPTION
Fixes #192.

@beeman's diagnosis on the issue was right, and the loop is in `searchAndReplace` itself: replacements are applied sequentially over the accumulated content, so a later pair can rewrite an earlier pair's output.

Renaming the `counter` template to `my-counter` passes several name variants, all of which search for `counter`:

```
'counter' -> 'my-counter'   content becomes  my-counter
'counter' -> 'mycounter'    the counter inside my-counter matches again -> my-mycounter
'counter' -> 'my_counter'   and again        -> my-mymy_counter
```

which is exactly the `mymymycounter` in the report. It is not specific to kebab case or to the `counter` template: it triggers whenever a replacement value contains another search string.

The general shape is worth calling out too, since it corrupts values that have nothing to do with package names:

```js
searchAndReplace(dir, ['foo', 'bar'], ['bar', 'baz'])   // 'foo' became 'baz', not 'bar'
```

## Fix

All pairs are compiled into one alternation and applied in a single pass, so replaced text is never rescanned. Search strings are sorted longest-first, so the most specific pattern wins (`my_counter` is preferred over `counter`), and the first pair for a duplicated search string is the one that applies, matching the previous first-write-wins behavior.

The same replacer now drives path renaming, which had an identical sequential loop and the same bug for file and directory names.

## Verification

- 12 tests in `test/search-and-replace.test.ts` pass, 4 added: the issue's exact shape, the general rescan case, longest-match preference, and the path-rename path.
- Reverting `search-and-replace.ts` alone fails all 4 new tests.
- `pnpm lint` and `pnpm test:types` clean.
- Full suite is unchanged: 14 failures across 4 files, identical with and without this change (they reproduce on an unmodified checkout here).

## Relationship to #286

I have a separate open PR, #286, that dedupes package-name variants in `init-script-rename.ts`. That reduces how often duplicate pairs are generated, but it does not fix the underlying rescan, which still corrupts any content where one replacement contains another search string. This PR fixes the root cause and is independent; either can land first, and #286 becomes a tidiness improvement rather than a fix.
