### PR TITLE
fix: recognise Windows paths when detecting a local template

### DIFF
--- a/.changeset/windows-local-template-path.md
+++ b/.changeset/windows-local-template-path.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Recognise Windows paths when detecting a local template. `findTemplate` tested for a local path with `startsWith('/')`, `'./'` and `'../'` but resolved it with the platform-aware `isAbsolute`, so no local path worked on Windows: `C:\tpl` fell through to the named-template lookup, and `C:/tpl` was treated as an external template with `C:` read as a giget provider prefix

--- a/src/utils/find-template.ts
+++ b/src/utils/find-template.ts
@@ -13,8 +13,12 @@ export function findTemplate({
   templates: TemplateJsonTemplate[]
   verbose: boolean
 }): Template {
-  // Check if it's a local file path (absolute or relative)
-  const isLocalPath = name.startsWith('/') || name.startsWith('./') || name.startsWith('../')
+  // Check if it's a local file path (absolute or relative).
+  // `isAbsolute` rather than a leading `/` so Windows paths like `C:\tpl` and
+  // `C:/tpl` are recognised: the latter contains a `/` and was otherwise
+  // treated as an external template, handing giget `C:` as a provider prefix.
+  // The relative test accepts both separators for the same reason.
+  const isLocalPath = isAbsolute(name) || /^\.\.?[/\\]/.test(name)
 
   if (isLocalPath) {
     // Resolve to absolute path

--- a/test/find-template.test.ts
+++ b/test/find-template.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { findTemplate } from '../src/utils/find-template'
+
+vi.mock('@clack/prompts', () => ({ log: { info: vi.fn(), warning: vi.fn() } }))
+
+const templates = [{ description: 'a known template', id: 'gh:solana-foundation/templates/known', name: 'known' }]
+const isWindows = sep === '\\'
+
+function find(name: string) {
+  return findTemplate({ name, templates, verbose: false })
+}
+
+describe('findTemplate', () => {
+  it('resolves a named template', () => {
+    expect(find('known').id).toBe('gh:solana-foundation/templates/known')
+  })
+
+  it('treats an owner/repo name as an external template', () => {
+    expect(find('solana-foundation/templates').id).toBe('gh:solana-foundation/templates')
+  })
+
+  it('treats an absolute path as local, on either platform', () => {
+    // On Windows an absolute path is `C:\tpl`, which holds no `/` and used to
+    // fall through to the named-template lookup. Spelled `C:/tpl` it does hold
+    // a `/`, so it was treated as external and giget got `C:` as a provider.
+    const dir = mkdtempSync(join(tmpdir(), 'csd-'))
+    expect(find(dir).id).toBe(`local:${dir}`)
+    if (isWindows) {
+      expect(find(dir.replaceAll('\\', '/')).id.startsWith('local:')).toBe(true)
+    }
+  })
+
+  it('treats a relative path as local with either separator', () => {
+    const names = ['./nope', '../nope', ...(isWindows ? [String.raw`.\nope`, String.raw`..\nope`] : [])]
+    for (const name of names) {
+      expect(() => find(name)).toThrow(/Local template path does not exist/)
+    }
+  })
+
+  it('does not mistake a dotted template name for a path', () => {
+    expect(() => find('..nope')).toThrow(/not found/)
+  })
+})


### PR DESCRIPTION
### What

`findTemplate` decides whether a name is a local path using hardcoded POSIX prefixes, then resolves it with the platform-aware `isAbsolute`:

```ts
const isLocalPath = name.startsWith('/') || name.startsWith('./') || name.startsWith('../')
...
const absolutePath = isAbsolute(name) ? name : resolve(process.cwd(), name)
```

Those two disagree on Windows, and the result is that **no local template path works there**:

| input | today | why |
| --- | --- | --- |
| `C:\tpl` | `Template C:\tpl not found` | holds no `/`, so it falls through to the named-template lookup |
| `C:/tpl` | treated as an **external** template | holds a `/`, and since it also holds a `:` the id is passed through unchanged, so giget sees `C:` as a provider prefix |
| `.\tpl`, `..\tpl` | `Template ... not found` | matches neither prefix |

The `C:/tpl` case is the unpleasant one: it doesn't error, it quietly tries to fetch a remote template.

### The change

Use the `isAbsolute` that is already imported for the absolute case, and accept either separator for the relative one:

```ts
const isLocalPath = isAbsolute(name) || /^\.\.?[/\]/.test(name)
```

POSIX behaviour is unchanged. `/tpl`, `./tpl` and `../tpl` are still local, `owner/repo` is still external, and `C:/tpl` on Linux still goes down the external path because `isAbsolute` is false there.

### Verification

Added `test/find-template.test.ts` with five cases, including the Windows shapes guarded on `sep`. I confirmed the two path tests fail without the source change and that the three platform-neutral ones pass either way, so they isolate the change.

`tsc --noEmit` clean, ESLint clean. The repo suite has 14 pre-existing failures in `create-app-task-install-skills` and `get-package-json`; I checked the count is identical on a clean tree, so they are unrelated to this change.