### PR TITLE
test: drop mock-fs so the suite runs on Node 26

### DIFF
--- a/.changeset/drop-mock-fs-node26.md
+++ b/.changeset/drop-mock-fs-node26.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Drop `mock-fs` from the test suite so it runs on Node 26. `mock-fs` throws at import time there (tschaub/mock-fs#447), which took down `search-and-replace.test.ts` as a whole and failed the `Test & Lint on Node current` job on every pull request. It was used in one test, to make a single `readFile` fail, so that call is stubbed instead

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.31.1",
-    "@types/mock-fs": "^4.13.4",
     "@types/node": "^24.3.1",
     "@types/semver": "^7.7.1",
     "@types/update-notifier": "^6.0.8",
@@ -66,7 +65,6 @@
     "eslint-plugin-sort": "^4.0.0",
     "lefthook": "^1.12.4",
     "memfs": "^4.64.0",
-    "mock-fs": "^5.5.0",
     "pkg-pr-new": "^0.0.79",
     "prettier": "^3.9.6",
     "publint": "0.3.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@24.9.1)
-      '@types/mock-fs':
-        specifier: ^4.13.4
-        version: 4.13.4
       '@types/node':
         specifier: ^24.3.1
         version: 24.9.1
@@ -78,9 +75,6 @@ importers:
       memfs:
         specifier: ^4.64.0
         version: 4.64.0(tslib@2.8.1)
-      mock-fs:
-        specifier: ^5.5.0
-        version: 5.5.0
       pkg-pr-new:
         specifier: ^0.0.79
         version: 0.0.79
@@ -906,9 +900,6 @@ packages:
 
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
-
-  '@types/mock-fs@4.13.4':
-    resolution: {integrity: sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2079,10 +2070,6 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  mock-fs@5.5.0:
-    resolution: {integrity: sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==}
-    engines: {node: '>=12.0.0'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3652,10 +3639,6 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
-  '@types/mock-fs@4.13.4':
-    dependencies:
-      '@types/node': 24.9.1
-
   '@types/node@12.20.55': {}
 
   '@types/node@24.9.1':
@@ -4891,8 +4874,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
-
-  mock-fs@5.5.0: {}
 
   mri@1.2.0: {}
 

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -1,10 +1,19 @@
 // test/search-and-replace.test.ts
-import mockFs from 'mock-fs'
 import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { searchAndReplace } from '../src/utils/search-and-replace'
+
+// Only `readFile` is stubbed, and only for the error test below. mock-fs used
+// to provide that by creating a mode 0o000 file, but it patches Node's fs
+// internals and throws at import time on Node 26 (tschaub/mock-fs#447), which
+// failed the whole suite on the `current` matrix leg. Everything else in this
+// file already works against a real temp directory.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, readFile: vi.fn(actual.readFile) }
+})
 
 describe('searchAndReplace', () => {
   let tempDir: string
@@ -119,15 +128,8 @@ describe('searchAndReplace', () => {
   it('should handle errors gracefully', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    // Mock the file system and simulate an error for readFile
-    mockFs({
-      [tempDir]: {
-        'file1.txt': mockFs.file({
-          content: 'Hello world',
-          mode: 0o000, // No read permissions, to trigger an error
-        }),
-      },
-    })
+    // Make the first file read fail, the way an unreadable file would
+    vi.mocked(readFile).mockRejectedValueOnce(new Error('EACCES: permission denied, open'))
 
     // Run searchAndReplace and expect it to handle the error without throwing
     await searchAndReplace(tempDir, ['Hello'], ['Hi'], false, true)
@@ -135,8 +137,6 @@ describe('searchAndReplace', () => {
     // Verify that an error was logged
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Error processing file'), expect.any(Error))
 
-    // Restore the mocked file system and the console spy
-    mockFs.restore()
     consoleErrorSpy.mockRestore()
   })
 })


### PR DESCRIPTION
### What

`Test & Lint on Node current` fails on every pull request right now. It is not a test failure, it is a whole-file crash:

```
FAIL test/search-and-replace.test.ts [ test/search-and-replace.test.ts ]
TypeError: Cannot read properties of undefined (reading 'read')
Test Files  1 failed | 33 passed (34)
     Tests  162 passed (162)
```

The matrix in that same run makes the cause unambiguous, since only the Node version differs:

| job | Node | result |
| --- | --- | --- |
| `Node current` | **v26.8.1** | **failure** |
| `Node lts/*` | v24.19.0 | success |
| `22.12.0` | v22.12.0 | success |

`mock-fs` patches Node's `fs` internals and throws at import time on Node 26, tracked upstream as [tschaub/mock-fs#447](https://github.com/tschaub/mock-fs/issues/447). Because it fails at import, it takes the file down before any test runs. There is nothing to bump to: 5.5.0 is already the latest and was published in February 2025.

### The change

`mock-fs` is used in exactly one test, to create a mode `0o000` file so `readFile` fails. Every other test in the file already runs against a real temp directory from `mkdtemp`. So the fix is to stub just that one call:

```ts
vi.mock('node:fs/promises', async (importOriginal) => {
  const actual = await importOriginal<typeof import('node:fs/promises')>()
  return { ...actual, readFile: vi.fn(actual.readFile) }
})
```

and in the error test, `vi.mocked(readFile).mockRejectedValueOnce(...)`. Everything else passes straight through to the real module.

That removes the dependency entirely, which is also why `package.json` and the lockfile change here.

As a side benefit it drops a mode-based test, which never actually exercised the intended path on Windows or as root, where the read would have succeeded anyway.

### Verification

The rewritten test still earns its keep: I removed the `console.error` from `processFile`'s catch block and confirmed it fails, then restored it. So this is not weakening coverage to make a suite pass.

`test/search-and-replace.test.ts` is 8/8 passing, `tsc --noEmit` and ESLint are clean, and no `mock-fs` reference remains outside the explanatory comment.

The repo has 14 pre-existing failures across `create-app-task-install-skills`, `get-package-json`, `init-script-delete` and `init-script-rename` when run on Windows. I verified the count is identical before and after this change, and none of them are in the file touched here.

This is independent of #288 and can land on its own.